### PR TITLE
Utf-8 encode 2016/20161108__ak__general__precinct.csv

### DIFF
--- a/2016/20161108__ak__general__precinct.csv
+++ b/2016/20161108__ak__general__precinct.csv
@@ -20,8 +20,8 @@
 "1","01-446 Aurora ","U.S. House","1","NP ","Write-in 50 ",4
 "1","01-446 Aurora ","State House","1","DEM ","Kawasaki, Scott J.  ",633
 "1","01-446 Aurora ","State House","1","NP ","Write-in 20 ",74
-"1","01-446 Aurora ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",565
-"1","01-446 Aurora ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",284
+"1","01-446 Aurora ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",565
+"1","01-446 Aurora ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",284
 "1","01-446 Aurora ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",372
 "1","01-446 Aurora ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",462
 "1","01-446 Aurora ","Supreme Crt-Justice Bolger ","","NP ","YES ",460
@@ -67,8 +67,8 @@
 "1","01-455 Fairbanks No. 1 ","U.S. House","1","NP ","Write-in 50 ",0
 "1","01-455 Fairbanks No. 1 ","State House","1","DEM ","Kawasaki, Scott J.  ",142
 "1","01-455 Fairbanks No. 1 ","State House","1","NP ","Write-in 20 ",17
-"1","01-455 Fairbanks No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",134
-"1","01-455 Fairbanks No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",62
+"1","01-455 Fairbanks No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",134
+"1","01-455 Fairbanks No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",62
 "1","01-455 Fairbanks No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",94
 "1","01-455 Fairbanks No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",96
 "1","01-455 Fairbanks No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",114
@@ -114,8 +114,8 @@
 "1","01-465 Fairbanks No. 2 ","U.S. House","1","NP ","Write-in 50 ",0
 "1","01-465 Fairbanks No. 2 ","State House","1","DEM ","Kawasaki, Scott J.  ",233
 "1","01-465 Fairbanks No. 2 ","State House","1","NP ","Write-in 20 ",25
-"1","01-465 Fairbanks No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",192
-"1","01-465 Fairbanks No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",120
+"1","01-465 Fairbanks No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",192
+"1","01-465 Fairbanks No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",120
 "1","01-465 Fairbanks No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",129
 "1","01-465 Fairbanks No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",174
 "1","01-465 Fairbanks No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",163
@@ -161,8 +161,8 @@
 "1","01-470 Fairbanks No. 3 ","U.S. House","1","NP ","Write-in 50 ",1
 "1","01-470 Fairbanks No. 3 ","State House","1","DEM ","Kawasaki, Scott J.  ",356
 "1","01-470 Fairbanks No. 3 ","State House","1","NP ","Write-in 20 ",55
-"1","01-470 Fairbanks No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",327
-"1","01-470 Fairbanks No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",166
+"1","01-470 Fairbanks No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",327
+"1","01-470 Fairbanks No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",166
 "1","01-470 Fairbanks No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",237
 "1","01-470 Fairbanks No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",235
 "1","01-470 Fairbanks No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",281
@@ -208,8 +208,8 @@
 "1","01-475 Fairbanks No. 4 ","U.S. House","1","NP ","Write-in 50 ",1
 "1","01-475 Fairbanks No. 4 ","State House","1","DEM ","Kawasaki, Scott J.  ",181
 "1","01-475 Fairbanks No. 4 ","State House","1","NP ","Write-in 20 ",29
-"1","01-475 Fairbanks No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",164
-"1","01-475 Fairbanks No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",108
+"1","01-475 Fairbanks No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",164
+"1","01-475 Fairbanks No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",108
 "1","01-475 Fairbanks No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",127
 "1","01-475 Fairbanks No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",135
 "1","01-475 Fairbanks No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",139
@@ -255,8 +255,8 @@
 "1","01-480 Fairbanks No. 5 ","U.S. House","1","NP ","Write-in 50 ",2
 "1","01-480 Fairbanks No. 5 ","State House","1","DEM ","Kawasaki, Scott J.  ",487
 "1","01-480 Fairbanks No. 5 ","State House","1","NP ","Write-in 20 ",67
-"1","01-480 Fairbanks No. 5 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",470
-"1","01-480 Fairbanks No. 5 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",224
+"1","01-480 Fairbanks No. 5 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",470
+"1","01-480 Fairbanks No. 5 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",224
 "1","01-480 Fairbanks No. 5 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",304
 "1","01-480 Fairbanks No. 5 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",365
 "1","01-480 Fairbanks No. 5 ","Supreme Crt-Justice Bolger ","","NP ","YES ",406
@@ -302,8 +302,8 @@
 "1","01-485 Fairbanks No. 6 ","U.S. House","1","NP ","Write-in 50 ",1
 "1","01-485 Fairbanks No. 6 ","State House","1","DEM ","Kawasaki, Scott J.  ",264
 "1","01-485 Fairbanks No. 6 ","State House","1","NP ","Write-in 20 ",32
-"1","01-485 Fairbanks No. 6 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",227
-"1","01-485 Fairbanks No. 6 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",125
+"1","01-485 Fairbanks No. 6 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",227
+"1","01-485 Fairbanks No. 6 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",125
 "1","01-485 Fairbanks No. 6 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",132
 "1","01-485 Fairbanks No. 6 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",203
 "1","01-485 Fairbanks No. 6 ","Supreme Crt-Justice Bolger ","","NP ","YES ",182
@@ -349,8 +349,8 @@
 "1","01-490 Fairbanks No. 7 ","U.S. House","1","NP ","Write-in 50 ",1
 "1","01-490 Fairbanks No. 7 ","State House","1","DEM ","Kawasaki, Scott J.  ",398
 "1","01-490 Fairbanks No. 7 ","State House","1","NP ","Write-in 20 ",24
-"1","01-490 Fairbanks No. 7 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",330
-"1","01-490 Fairbanks No. 7 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",160
+"1","01-490 Fairbanks No. 7 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",330
+"1","01-490 Fairbanks No. 7 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",160
 "1","01-490 Fairbanks No. 7 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",201
 "1","01-490 Fairbanks No. 7 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",281
 "1","01-490 Fairbanks No. 7 ","Supreme Crt-Justice Bolger ","","NP ","YES ",258
@@ -396,8 +396,8 @@
 "1","01-495 Fairbanks No. 10 ","U.S. House","1","NP ","Write-in 50 ",1
 "1","01-495 Fairbanks No. 10 ","State House","1","DEM ","Kawasaki, Scott J.  ",123
 "1","01-495 Fairbanks No. 10 ","State House","1","NP ","Write-in 20 ",22
-"1","01-495 Fairbanks No. 10 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",116
-"1","01-495 Fairbanks No. 10 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",80
+"1","01-495 Fairbanks No. 10 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",116
+"1","01-495 Fairbanks No. 10 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",80
 "1","01-495 Fairbanks No. 10 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",82
 "1","01-495 Fairbanks No. 10 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",108
 "1","01-495 Fairbanks No. 10 ","Supreme Crt-Justice Bolger ","","NP ","YES ",102
@@ -444,8 +444,8 @@
 "2","02-345 Badger No. 2 ","State House","2","REP ","Thompson, Steve M.  ",838
 "2","02-345 Badger No. 2 ","State House","2","DEM ","Holdaway, Truno N. L ",192
 "2","02-345 Badger No. 2 ","State House","2","NP ","Write-in 30 ",13
-"2","02-345 Badger No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",637
-"2","02-345 Badger No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",435
+"2","02-345 Badger No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",637
+"2","02-345 Badger No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",435
 "2","02-345 Badger No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",354
 "2","02-345 Badger No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",685
 "2","02-345 Badger No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",526
@@ -492,8 +492,8 @@
 "2","02-355 Fairbanks No. 8 ","State House","2","REP ","Thompson, Steve M.  ",384
 "2","02-355 Fairbanks No. 8 ","State House","2","DEM ","Holdaway, Truno N. L ",177
 "2","02-355 Fairbanks No. 8 ","State House","2","NP ","Write-in 30 ",5
-"2","02-355 Fairbanks No. 8 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",400
-"2","02-355 Fairbanks No. 8 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",189
+"2","02-355 Fairbanks No. 8 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",400
+"2","02-355 Fairbanks No. 8 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",189
 "2","02-355 Fairbanks No. 8 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",245
 "2","02-355 Fairbanks No. 8 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",322
 "2","02-355 Fairbanks No. 8 ","Supreme Crt-Justice Bolger ","","NP ","YES ",316
@@ -540,8 +540,8 @@
 "2","02-365 Fairbanks No. 9 ","State House","2","REP ","Thompson, Steve M.  ",706
 "2","02-365 Fairbanks No. 9 ","State House","2","DEM ","Holdaway, Truno N. L ",216
 "2","02-365 Fairbanks No. 9 ","State House","2","NP ","Write-in 30 ",7
-"2","02-365 Fairbanks No. 9 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",614
-"2","02-365 Fairbanks No. 9 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",328
+"2","02-365 Fairbanks No. 9 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",614
+"2","02-365 Fairbanks No. 9 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",328
 "2","02-365 Fairbanks No. 9 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",368
 "2","02-365 Fairbanks No. 9 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",545
 "2","02-365 Fairbanks No. 9 ","Supreme Crt-Justice Bolger ","","NP ","YES ",510
@@ -588,8 +588,8 @@
 "2","02-375 Fort Wainwright ","State House","2","REP ","Thompson, Steve M.  ",237
 "2","02-375 Fort Wainwright ","State House","2","DEM ","Holdaway, Truno N. L ",86
 "2","02-375 Fort Wainwright ","State House","2","NP ","Write-in 30 ",5
-"2","02-375 Fort Wainwright ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",274
-"2","02-375 Fort Wainwright ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",68
+"2","02-375 Fort Wainwright ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",274
+"2","02-375 Fort Wainwright ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",68
 "2","02-375 Fort Wainwright ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",144
 "2","02-375 Fort Wainwright ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",186
 "2","02-375 Fort Wainwright ","Supreme Crt-Justice Bolger ","","NP ","YES ",164
@@ -640,8 +640,8 @@
 "3","03-130 Badger No. 1 ","State House","3","REP ","Wilson, Tammie ",622
 "3","03-130 Badger No. 1 ","State House","3","NA ","Olson, Jeanne L.  ",377
 "3","03-130 Badger No. 1 ","State House","3","NP ","Write-in 40 ",0
-"3","03-130 Badger No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",618
-"3","03-130 Badger No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",442
+"3","03-130 Badger No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",618
+"3","03-130 Badger No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",442
 "3","03-130 Badger No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",347
 "3","03-130 Badger No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",680
 "3","03-130 Badger No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",503
@@ -692,8 +692,8 @@
 "3","03-135 Chena Lakes ","State House","3","REP ","Wilson, Tammie ",618
 "3","03-135 Chena Lakes ","State House","3","NA ","Olson, Jeanne L.  ",325
 "3","03-135 Chena Lakes ","State House","3","NP ","Write-in 40 ",2
-"3","03-135 Chena Lakes ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",602
-"3","03-135 Chena Lakes ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",397
+"3","03-135 Chena Lakes ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",602
+"3","03-135 Chena Lakes ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",397
 "3","03-135 Chena Lakes ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",309
 "3","03-135 Chena Lakes ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",671
 "3","03-135 Chena Lakes ","Supreme Crt-Justice Bolger ","","NP ","YES ",483
@@ -744,8 +744,8 @@
 "3","03-165 Newby ","State House","3","REP ","Wilson, Tammie ",724
 "3","03-165 Newby ","State House","3","NA ","Olson, Jeanne L.  ",421
 "3","03-165 Newby ","State House","3","NP ","Write-in 40 ",3
-"3","03-165 Newby ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",797
-"3","03-165 Newby ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",432
+"3","03-165 Newby ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",797
+"3","03-165 Newby ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",432
 "3","03-165 Newby ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",358
 "3","03-165 Newby ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",830
 "3","03-165 Newby ","Supreme Crt-Justice Bolger ","","NP ","YES ",594
@@ -796,8 +796,8 @@
 "3","03-175 North Pole ","State House","3","REP ","Wilson, Tammie ",322
 "3","03-175 North Pole ","State House","3","NA ","Olson, Jeanne L.  ",207
 "3","03-175 North Pole ","State House","3","NP ","Write-in 40 ",2
-"3","03-175 North Pole ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",359
-"3","03-175 North Pole ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",218
+"3","03-175 North Pole ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",359
+"3","03-175 North Pole ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",218
 "3","03-175 North Pole ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",219
 "3","03-175 North Pole ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",348
 "3","03-175 North Pole ","Supreme Crt-Justice Bolger ","","NP ","YES ",313
@@ -848,8 +848,8 @@
 "3","03-183 Plack ","State House","3","REP ","Wilson, Tammie ",673
 "3","03-183 Plack ","State House","3","NA ","Olson, Jeanne L.  ",338
 "3","03-183 Plack ","State House","3","NP ","Write-in 40 ",3
-"3","03-183 Plack ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",608
-"3","03-183 Plack ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",432
+"3","03-183 Plack ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",608
+"3","03-183 Plack ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",432
 "3","03-183 Plack ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",284
 "3","03-183 Plack ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",730
 "3","03-183 Plack ","Supreme Crt-Justice Bolger ","","NP ","YES ",491
@@ -898,8 +898,8 @@
 "4","04-230 Ester ","State Senate","B","NP ","Write-in 30 ",0
 "4","04-230 Ester ","State House","4","DEM ","Guttenberg, David ",354
 "4","04-230 Ester ","State House","4","NP ","Write-in 20 ",31
-"4","04-230 Ester ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",342
-"4","04-230 Ester ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",151
+"4","04-230 Ester ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",342
+"4","04-230 Ester ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",151
 "4","04-230 Ester ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",257
 "4","04-230 Ester ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",219
 "4","04-230 Ester ","Supreme Crt-Justice Bolger ","","NP ","YES ",285
@@ -948,8 +948,8 @@
 "4","04-240 Farmers Loop ","State Senate","B","NP ","Write-in 30 ",7
 "4","04-240 Farmers Loop ","State House","4","DEM ","Guttenberg, David ",823
 "4","04-240 Farmers Loop ","State House","4","NP ","Write-in 20 ",53
-"4","04-240 Farmers Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",792
-"4","04-240 Farmers Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",331
+"4","04-240 Farmers Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",792
+"4","04-240 Farmers Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",331
 "4","04-240 Farmers Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",625
 "4","04-240 Farmers Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",456
 "4","04-240 Farmers Loop ","Supreme Crt-Justice Bolger ","","NP ","YES ",700
@@ -998,8 +998,8 @@
 "4","04-250 Goldstream No. 1 ","State Senate","B","NP ","Write-in 30 ",4
 "4","04-250 Goldstream No. 1 ","State House","4","DEM ","Guttenberg, David ",355
 "4","04-250 Goldstream No. 1 ","State House","4","NP ","Write-in 20 ",35
-"4","04-250 Goldstream No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",339
-"4","04-250 Goldstream No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",152
+"4","04-250 Goldstream No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",339
+"4","04-250 Goldstream No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",152
 "4","04-250 Goldstream No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",237
 "4","04-250 Goldstream No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",240
 "4","04-250 Goldstream No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",262
@@ -1048,8 +1048,8 @@
 "4","04-260 Goldstream No. 2 ","State Senate","B","NP ","Write-in 30 ",6
 "4","04-260 Goldstream No. 2 ","State House","4","DEM ","Guttenberg, David ",570
 "4","04-260 Goldstream No. 2 ","State House","4","NP ","Write-in 20 ",29
-"4","04-260 Goldstream No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",514
-"4","04-260 Goldstream No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",218
+"4","04-260 Goldstream No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",514
+"4","04-260 Goldstream No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",218
 "4","04-260 Goldstream No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",393
 "4","04-260 Goldstream No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",315
 "4","04-260 Goldstream No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",421
@@ -1098,8 +1098,8 @@
 "4","04-265 Steese East-Gilmore ","State Senate","B","NP ","Write-in 30 ",12
 "4","04-265 Steese East-Gilmore ","State House","4","DEM ","Guttenberg, David ",755
 "4","04-265 Steese East-Gilmore ","State House","4","NP ","Write-in 20 ",123
-"4","04-265 Steese East-Gilmore ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",825
-"4","04-265 Steese East-Gilmore ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",511
+"4","04-265 Steese East-Gilmore ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",825
+"4","04-265 Steese East-Gilmore ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",511
 "4","04-265 Steese East-Gilmore ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",492
 "4","04-265 Steese East-Gilmore ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",800
 "4","04-265 Steese East-Gilmore ","Supreme Crt-Justice Bolger ","","NP ","YES ",681
@@ -1148,8 +1148,8 @@
 "4","04-270 Steese West ","State Senate","B","NP ","Write-in 30 ",11
 "4","04-270 Steese West ","State House","4","DEM ","Guttenberg, David ",869
 "4","04-270 Steese West ","State House","4","NP ","Write-in 20 ",115
-"4","04-270 Steese West ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",895
-"4","04-270 Steese West ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",546
+"4","04-270 Steese West ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",895
+"4","04-270 Steese West ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",546
 "4","04-270 Steese West ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",556
 "4","04-270 Steese West ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",825
 "4","04-270 Steese West ","Supreme Crt-Justice Bolger ","","NP ","YES ",733
@@ -1198,8 +1198,8 @@
 "4","04-280 University Hills ","State Senate","B","NP ","Write-in 30 ",3
 "4","04-280 University Hills ","State House","4","DEM ","Guttenberg, David ",163
 "4","04-280 University Hills ","State House","4","NP ","Write-in 20 ",13
-"4","04-280 University Hills ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",157
-"4","04-280 University Hills ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",51
+"4","04-280 University Hills ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",157
+"4","04-280 University Hills ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",51
 "4","04-280 University Hills ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",115
 "4","04-280 University Hills ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",85
 "4","04-280 University Hills ","Supreme Crt-Justice Bolger ","","NP ","YES ",123
@@ -1246,8 +1246,8 @@
 "5","05-580 Airport ","State House","5","REP ","Lojewski, Aaron ",87
 "5","05-580 Airport ","State House","5","DEM ","Wool, Adam ",40
 "5","05-580 Airport ","State House","5","NP ","Write-in 30 ",1
-"5","05-580 Airport ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",76
-"5","05-580 Airport ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",48
+"5","05-580 Airport ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",76
+"5","05-580 Airport ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",48
 "5","05-580 Airport ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",49
 "5","05-580 Airport ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",71
 "5","05-580 Airport ","Supreme Crt-Justice Bolger ","","NP ","YES ",56
@@ -1294,8 +1294,8 @@
 "5","05-582 Chena ","State House","5","REP ","Lojewski, Aaron ",862
 "5","05-582 Chena ","State House","5","DEM ","Wool, Adam ",1072
 "5","05-582 Chena ","State House","5","NP ","Write-in 30 ",7
-"5","05-582 Chena ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1355
-"5","05-582 Chena ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",596
+"5","05-582 Chena ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1355
+"5","05-582 Chena ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",596
 "5","05-582 Chena ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",933
 "5","05-582 Chena ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",943
 "5","05-582 Chena ","Supreme Crt-Justice Bolger ","","NP ","YES ",1146
@@ -1342,8 +1342,8 @@
 "5","05-586 Geist ","State House","5","REP ","Lojewski, Aaron ",285
 "5","05-586 Geist ","State House","5","DEM ","Wool, Adam ",371
 "5","05-586 Geist ","State House","5","NP ","Write-in 30 ",1
-"5","05-586 Geist ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",436
-"5","05-586 Geist ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",211
+"5","05-586 Geist ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",436
+"5","05-586 Geist ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",211
 "5","05-586 Geist ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",324
 "5","05-586 Geist ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",302
 "5","05-586 Geist ","Supreme Crt-Justice Bolger ","","NP ","YES ",350
@@ -1390,8 +1390,8 @@
 "5","05-587 Lakeview ","State House","5","REP ","Lojewski, Aaron ",83
 "5","05-587 Lakeview ","State House","5","DEM ","Wool, Adam ",50
 "5","05-587 Lakeview ","State House","5","NP ","Write-in 30 ",3
-"5","05-587 Lakeview ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",71
-"5","05-587 Lakeview ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",65
+"5","05-587 Lakeview ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",71
+"5","05-587 Lakeview ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",65
 "5","05-587 Lakeview ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",46
 "5","05-587 Lakeview ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",88
 "5","05-587 Lakeview ","Supreme Crt-Justice Bolger ","","NP ","YES ",60
@@ -1438,8 +1438,8 @@
 "5","05-588 Pike ","State House","5","REP ","Lojewski, Aaron ",132
 "5","05-588 Pike ","State House","5","DEM ","Wool, Adam ",101
 "5","05-588 Pike ","State House","5","NP ","Write-in 30 ",0
-"5","05-588 Pike ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",136
-"5","05-588 Pike ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",100
+"5","05-588 Pike ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",136
+"5","05-588 Pike ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",100
 "5","05-588 Pike ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",79
 "5","05-588 Pike ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",148
 "5","05-588 Pike ","Supreme Crt-Justice Bolger ","","NP ","YES ",121
@@ -1486,8 +1486,8 @@
 "5","05-590 Richardson ","State House","5","REP ","Lojewski, Aaron ",116
 "5","05-590 Richardson ","State House","5","DEM ","Wool, Adam ",32
 "5","05-590 Richardson ","State House","5","NP ","Write-in 30 ",2
-"5","05-590 Richardson ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",81
-"5","05-590 Richardson ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",74
+"5","05-590 Richardson ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",81
+"5","05-590 Richardson ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",74
 "5","05-590 Richardson ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",44
 "5","05-590 Richardson ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",102
 "5","05-590 Richardson ","Supreme Crt-Justice Bolger ","","NP ","YES ",67
@@ -1534,8 +1534,8 @@
 "5","05-592 Shanly ","State House","5","REP ","Lojewski, Aaron ",208
 "5","05-592 Shanly ","State House","5","DEM ","Wool, Adam ",205
 "5","05-592 Shanly ","State House","5","NP ","Write-in 30 ",2
-"5","05-592 Shanly ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",286
-"5","05-592 Shanly ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",133
+"5","05-592 Shanly ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",286
+"5","05-592 Shanly ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",133
 "5","05-592 Shanly ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",192
 "5","05-592 Shanly ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",204
 "5","05-592 Shanly ","Supreme Crt-Justice Bolger ","","NP ","YES ",222
@@ -1582,8 +1582,8 @@
 "5","05-594 University Campus ","State House","5","REP ","Lojewski, Aaron ",22
 "5","05-594 University Campus ","State House","5","DEM ","Wool, Adam ",58
 "5","05-594 University Campus ","State House","5","NP ","Write-in 30 ",0
-"5","05-594 University Campus ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",68
-"5","05-594 University Campus ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",15
+"5","05-594 University Campus ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",68
+"5","05-594 University Campus ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",15
 "5","05-594 University Campus ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",53
 "5","05-594 University Campus ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "5","05-594 University Campus ","Supreme Crt-Justice Bolger ","","NP ","YES ",46
@@ -1630,8 +1630,8 @@
 "5","05-596 University West ","State House","5","REP ","Lojewski, Aaron ",484
 "5","05-596 University West ","State House","5","DEM ","Wool, Adam ",534
 "5","05-596 University West ","State House","5","NP ","Write-in 30 ",2
-"5","05-596 University West ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",697
-"5","05-596 University West ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",333
+"5","05-596 University West ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",697
+"5","05-596 University West ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",333
 "5","05-596 University West ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",467
 "5","05-596 University West ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",525
 "5","05-596 University West ","Supreme Crt-Justice Bolger ","","NP ","YES ",570
@@ -1678,8 +1678,8 @@
 "6","06-005 Anderson ","State House","6","REP ","Talerico, David M.  ",57
 "6","06-005 Anderson ","State House","6","DEM ","Land, Jason T.  ",7
 "6","06-005 Anderson ","State House","6","NP ","Write-in 40 ",0
-"6","06-005 Anderson ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",45
-"6","06-005 Anderson ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",23
+"6","06-005 Anderson ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",45
+"6","06-005 Anderson ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",23
 "6","06-005 Anderson ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",25
 "6","06-005 Anderson ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",37
 "6","06-005 Anderson ","Supreme Crt-Justice Bolger ","","NP ","YES ",27
@@ -1726,8 +1726,8 @@
 "6","06-007 Arctic Village ","State House","6","REP ","Talerico, David M.  ",4
 "6","06-007 Arctic Village ","State House","6","DEM ","Land, Jason T.  ",56
 "6","06-007 Arctic Village ","State House","6","NP ","Write-in 40 ",0
-"6","06-007 Arctic Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",51
-"6","06-007 Arctic Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",12
+"6","06-007 Arctic Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",51
+"6","06-007 Arctic Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",12
 "6","06-007 Arctic Village ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",45
 "6","06-007 Arctic Village ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",17
 "6","06-007 Arctic Village ","Supreme Crt-Justice Bolger ","","NP ","YES ",42
@@ -1774,8 +1774,8 @@
 "6","06-010 Beaver ","State House","6","REP ","Talerico, David M.  ",8
 "6","06-010 Beaver ","State House","6","DEM ","Land, Jason T.  ",13
 "6","06-010 Beaver ","State House","6","NP ","Write-in 40 ",0
-"6","06-010 Beaver ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",18
-"6","06-010 Beaver ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",9
+"6","06-010 Beaver ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",18
+"6","06-010 Beaver ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",9
 "6","06-010 Beaver ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",15
 "6","06-010 Beaver ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "6","06-010 Beaver ","Supreme Crt-Justice Bolger ","","NP ","YES ",17
@@ -1822,8 +1822,8 @@
 "6","06-012 Cantwell ","State House","6","REP ","Talerico, David M.  ",73
 "6","06-012 Cantwell ","State House","6","DEM ","Land, Jason T.  ",25
 "6","06-012 Cantwell ","State House","6","NP ","Write-in 40 ",0
-"6","06-012 Cantwell ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",55
-"6","06-012 Cantwell ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",42
+"6","06-012 Cantwell ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",55
+"6","06-012 Cantwell ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",42
 "6","06-012 Cantwell ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",42
 "6","06-012 Cantwell ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",50
 "6","06-012 Cantwell ","Supreme Crt-Justice Bolger ","","NP ","YES ",41
@@ -1870,8 +1870,8 @@
 "6","06-015 Central ","State House","6","REP ","Talerico, David M.  ",34
 "6","06-015 Central ","State House","6","DEM ","Land, Jason T.  ",8
 "6","06-015 Central ","State House","6","NP ","Write-in 40 ",1
-"6","06-015 Central ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",20
-"6","06-015 Central ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",22
+"6","06-015 Central ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",20
+"6","06-015 Central ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",22
 "6","06-015 Central ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",14
 "6","06-015 Central ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",29
 "6","06-015 Central ","Supreme Crt-Justice Bolger ","","NP ","YES ",16
@@ -1918,8 +1918,8 @@
 "6","06-020 Chistochina ","State House","6","REP ","Talerico, David M.  ",68
 "6","06-020 Chistochina ","State House","6","DEM ","Land, Jason T.  ",16
 "6","06-020 Chistochina ","State House","6","NP ","Write-in 40 ",0
-"6","06-020 Chistochina ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",45
-"6","06-020 Chistochina ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",37
+"6","06-020 Chistochina ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",45
+"6","06-020 Chistochina ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",37
 "6","06-020 Chistochina ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",18
 "6","06-020 Chistochina ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",61
 "6","06-020 Chistochina ","Supreme Crt-Justice Bolger ","","NP ","YES ",32
@@ -1986,8 +1986,8 @@
 "6","06-023 Circle ","State House","6","REP ","Talerico, David M.  ",9
 "6","06-023 Circle ","State House","6","DEM ","Land, Jason T.  ",19
 "6","06-023 Circle ","State House","6","NP ","Write-in 40 ",0
-"6","06-023 Circle ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",22
-"6","06-023 Circle ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"6","06-023 Circle ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",22
+"6","06-023 Circle ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "6","06-023 Circle ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",15
 "6","06-023 Circle ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",12
 "6","06-023 Circle ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -2034,8 +2034,8 @@
 "6","06-024 Clear ","State House","6","REP ","Talerico, David M.  ",50
 "6","06-024 Clear ","State House","6","DEM ","Land, Jason T.  ",20
 "6","06-024 Clear ","State House","6","NP ","Write-in 40 ",0
-"6","06-024 Clear ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",42
-"6","06-024 Clear ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",30
+"6","06-024 Clear ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",42
+"6","06-024 Clear ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",30
 "6","06-024 Clear ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",23
 "6","06-024 Clear ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",45
 "6","06-024 Clear ","Supreme Crt-Justice Bolger ","","NP ","YES ",32
@@ -2082,8 +2082,8 @@
 "6","06-025 Copper Center ","State House","6","REP ","Talerico, David M.  ",173
 "6","06-025 Copper Center ","State House","6","DEM ","Land, Jason T.  ",72
 "6","06-025 Copper Center ","State House","6","NP ","Write-in 40 ",3
-"6","06-025 Copper Center ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",162
-"6","06-025 Copper Center ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",98
+"6","06-025 Copper Center ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",162
+"6","06-025 Copper Center ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",98
 "6","06-025 Copper Center ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",84
 "6","06-025 Copper Center ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",166
 "6","06-025 Copper Center ","Supreme Crt-Justice Bolger ","","NP ","YES ",98
@@ -2150,8 +2150,8 @@
 "6","06-026 Denali Park ","State House","6","REP ","Talerico, David M.  ",33
 "6","06-026 Denali Park ","State House","6","DEM ","Land, Jason T.  ",59
 "6","06-026 Denali Park ","State House","6","NP ","Write-in 40 ",1
-"6","06-026 Denali Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",74
-"6","06-026 Denali Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"6","06-026 Denali Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",74
+"6","06-026 Denali Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "6","06-026 Denali Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",71
 "6","06-026 Denali Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",17
 "6","06-026 Denali Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",63
@@ -2198,8 +2198,8 @@
 "6","06-027 Dot Lake ","State House","6","REP ","Talerico, David M.  ",37
 "6","06-027 Dot Lake ","State House","6","DEM ","Land, Jason T.  ",7
 "6","06-027 Dot Lake ","State House","6","NP ","Write-in 40 ",0
-"6","06-027 Dot Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",28
-"6","06-027 Dot Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",13
+"6","06-027 Dot Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",28
+"6","06-027 Dot Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",13
 "6","06-027 Dot Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",14
 "6","06-027 Dot Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",23
 "6","06-027 Dot Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",22
@@ -2246,8 +2246,8 @@
 "6","06-030 Eagle ","State House","6","REP ","Talerico, David M.  ",53
 "6","06-030 Eagle ","State House","6","DEM ","Land, Jason T.  ",32
 "6","06-030 Eagle ","State House","6","NP ","Write-in 40 ",0
-"6","06-030 Eagle ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",47
-"6","06-030 Eagle ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",40
+"6","06-030 Eagle ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",47
+"6","06-030 Eagle ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",40
 "6","06-030 Eagle ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",22
 "6","06-030 Eagle ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",62
 "6","06-030 Eagle ","Supreme Crt-Justice Bolger ","","NP ","YES ",36
@@ -2294,8 +2294,8 @@
 "6","06-033 Fort Yukon ","State House","6","REP ","Talerico, David M.  ",68
 "6","06-033 Fort Yukon ","State House","6","DEM ","Land, Jason T.  ",102
 "6","06-033 Fort Yukon ","State House","6","NP ","Write-in 40 ",0
-"6","06-033 Fort Yukon ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",137
-"6","06-033 Fort Yukon ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",39
+"6","06-033 Fort Yukon ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",137
+"6","06-033 Fort Yukon ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",39
 "6","06-033 Fort Yukon ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",76
 "6","06-033 Fort Yukon ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",96
 "6","06-033 Fort Yukon ","Supreme Crt-Justice Bolger ","","NP ","YES ",96
@@ -2342,8 +2342,8 @@
 "6","06-035 Gakona ","State House","6","REP ","Talerico, David M.  ",62
 "6","06-035 Gakona ","State House","6","DEM ","Land, Jason T.  ",25
 "6","06-035 Gakona ","State House","6","NP ","Write-in 40 ",1
-"6","06-035 Gakona ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",52
-"6","06-035 Gakona ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",38
+"6","06-035 Gakona ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",52
+"6","06-035 Gakona ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",38
 "6","06-035 Gakona ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",36
 "6","06-035 Gakona ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",54
 "6","06-035 Gakona ","Supreme Crt-Justice Bolger ","","NP ","YES ",39
@@ -2410,8 +2410,8 @@
 "6","06-040 Healy ","State House","6","REP ","Talerico, David M.  ",294
 "6","06-040 Healy ","State House","6","DEM ","Land, Jason T.  ",67
 "6","06-040 Healy ","State House","6","NP ","Write-in 40 ",2
-"6","06-040 Healy ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",218
-"6","06-040 Healy ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",130
+"6","06-040 Healy ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",218
+"6","06-040 Healy ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",130
 "6","06-040 Healy ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",157
 "6","06-040 Healy ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",170
 "6","06-040 Healy ","Supreme Crt-Justice Bolger ","","NP ","YES ",157
@@ -2458,8 +2458,8 @@
 "6","06-047 Kenny Lake ","State House","6","REP ","Talerico, David M.  ",95
 "6","06-047 Kenny Lake ","State House","6","DEM ","Land, Jason T.  ",41
 "6","06-047 Kenny Lake ","State House","6","NP ","Write-in 40 ",2
-"6","06-047 Kenny Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",81
-"6","06-047 Kenny Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",61
+"6","06-047 Kenny Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",81
+"6","06-047 Kenny Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",61
 "6","06-047 Kenny Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",44
 "6","06-047 Kenny Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",97
 "6","06-047 Kenny Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",58
@@ -2526,8 +2526,8 @@
 "6","06-050 Manley Hot Springs ","State House","6","REP ","Talerico, David M.  ",38
 "6","06-050 Manley Hot Springs ","State House","6","DEM ","Land, Jason T.  ",10
 "6","06-050 Manley Hot Springs ","State House","6","NP ","Write-in 40 ",0
-"6","06-050 Manley Hot Springs ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",26
-"6","06-050 Manley Hot Springs ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",20
+"6","06-050 Manley Hot Springs ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",26
+"6","06-050 Manley Hot Springs ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",20
 "6","06-050 Manley Hot Springs ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",11
 "6","06-050 Manley Hot Springs ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",34
 "6","06-050 Manley Hot Springs ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -2574,8 +2574,8 @@
 "6","06-053 Mentasta ","State House","6","REP ","Talerico, David M.  ",16
 "6","06-053 Mentasta ","State House","6","DEM ","Land, Jason T.  ",19
 "6","06-053 Mentasta ","State House","6","NP ","Write-in 40 ",0
-"6","06-053 Mentasta ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",20
-"6","06-053 Mentasta ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",14
+"6","06-053 Mentasta ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",20
+"6","06-053 Mentasta ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",14
 "6","06-053 Mentasta ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",15
 "6","06-053 Mentasta ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",20
 "6","06-053 Mentasta ","Supreme Crt-Justice Bolger ","","NP ","YES ",14
@@ -2642,8 +2642,8 @@
 "6","06-054 Minto ","State House","6","REP ","Talerico, David M.  ",29
 "6","06-054 Minto ","State House","6","DEM ","Land, Jason T.  ",35
 "6","06-054 Minto ","State House","6","NP ","Write-in 40 ",0
-"6","06-054 Minto ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",54
-"6","06-054 Minto ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"6","06-054 Minto ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",54
+"6","06-054 Minto ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "6","06-054 Minto ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",43
 "6","06-054 Minto ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",21
 "6","06-054 Minto ","Supreme Crt-Justice Bolger ","","NP ","YES ",43
@@ -2690,8 +2690,8 @@
 "6","06-056 Nenana ","State House","6","REP ","Talerico, David M.  ",203
 "6","06-056 Nenana ","State House","6","DEM ","Land, Jason T.  ",53
 "6","06-056 Nenana ","State House","6","NP ","Write-in 40 ",4
-"6","06-056 Nenana ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",140
-"6","06-056 Nenana ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",123
+"6","06-056 Nenana ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",140
+"6","06-056 Nenana ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",123
 "6","06-056 Nenana ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",68
 "6","06-056 Nenana ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",189
 "6","06-056 Nenana ","Supreme Crt-Justice Bolger ","","NP ","YES ",118
@@ -2738,8 +2738,8 @@
 "6","06-060 Northway ","State House","6","REP ","Talerico, David M.  ",39
 "6","06-060 Northway ","State House","6","DEM ","Land, Jason T.  ",32
 "6","06-060 Northway ","State House","6","NP ","Write-in 40 ",0
-"6","06-060 Northway ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",49
-"6","06-060 Northway ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",22
+"6","06-060 Northway ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",49
+"6","06-060 Northway ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",22
 "6","06-060 Northway ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",28
 "6","06-060 Northway ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",41
 "6","06-060 Northway ","Supreme Crt-Justice Bolger ","","NP ","YES ",32
@@ -2786,8 +2786,8 @@
 "6","06-070 Stevens Village ","State House","6","REP ","Talerico, David M.  ",3
 "6","06-070 Stevens Village ","State House","6","DEM ","Land, Jason T.  ",6
 "6","06-070 Stevens Village ","State House","6","NP ","Write-in 40 ",0
-"6","06-070 Stevens Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",7
-"6","06-070 Stevens Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",2
+"6","06-070 Stevens Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",7
+"6","06-070 Stevens Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",2
 "6","06-070 Stevens Village ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",4
 "6","06-070 Stevens Village ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",5
 "6","06-070 Stevens Village ","Supreme Crt-Justice Bolger ","","NP ","YES ",2
@@ -2834,8 +2834,8 @@
 "6","06-075 Tanacross ","State House","6","REP ","Talerico, David M.  ",4
 "6","06-075 Tanacross ","State House","6","DEM ","Land, Jason T.  ",22
 "6","06-075 Tanacross ","State House","6","NP ","Write-in 40 ",0
-"6","06-075 Tanacross ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",19
-"6","06-075 Tanacross ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",8
+"6","06-075 Tanacross ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",19
+"6","06-075 Tanacross ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",8
 "6","06-075 Tanacross ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",11
 "6","06-075 Tanacross ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "6","06-075 Tanacross ","Supreme Crt-Justice Bolger ","","NP ","YES ",13
@@ -2882,8 +2882,8 @@
 "6","06-080 Tanana ","State House","6","REP ","Talerico, David M.  ",41
 "6","06-080 Tanana ","State House","6","DEM ","Land, Jason T.  ",46
 "6","06-080 Tanana ","State House","6","NP ","Write-in 40 ",0
-"6","06-080 Tanana ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"6","06-080 Tanana ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",23
+"6","06-080 Tanana ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"6","06-080 Tanana ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",23
 "6","06-080 Tanana ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",50
 "6","06-080 Tanana ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",37
 "6","06-080 Tanana ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -2930,8 +2930,8 @@
 "6","06-085 Tetlin ","State House","6","REP ","Talerico, David M.  ",9
 "6","06-085 Tetlin ","State House","6","DEM ","Land, Jason T.  ",33
 "6","06-085 Tetlin ","State House","6","NP ","Write-in 40 ",0
-"6","06-085 Tetlin ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",34
-"6","06-085 Tetlin ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"6","06-085 Tetlin ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",34
+"6","06-085 Tetlin ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "6","06-085 Tetlin ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",26
 "6","06-085 Tetlin ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",17
 "6","06-085 Tetlin ","Supreme Crt-Justice Bolger ","","NP ","YES ",25
@@ -2978,8 +2978,8 @@
 "6","06-090 Tok ","State House","6","REP ","Talerico, David M.  ",326
 "6","06-090 Tok ","State House","6","DEM ","Land, Jason T.  ",131
 "6","06-090 Tok ","State House","6","NP ","Write-in 40 ",2
-"6","06-090 Tok ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",277
-"6","06-090 Tok ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",190
+"6","06-090 Tok ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",277
+"6","06-090 Tok ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",190
 "6","06-090 Tok ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",163
 "6","06-090 Tok ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",298
 "6","06-090 Tok ","Supreme Crt-Justice Bolger ","","NP ","YES ",188
@@ -3026,8 +3026,8 @@
 "6","06-095 Venetie ","State House","6","REP ","Talerico, David M.  ",21
 "6","06-095 Venetie ","State House","6","DEM ","Land, Jason T.  ",47
 "6","06-095 Venetie ","State House","6","NP ","Write-in 40 ",0
-"6","06-095 Venetie ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",46
-"6","06-095 Venetie ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",25
+"6","06-095 Venetie ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",46
+"6","06-095 Venetie ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",25
 "6","06-095 Venetie ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",38
 "6","06-095 Venetie ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",31
 "6","06-095 Venetie ","Supreme Crt-Justice Bolger ","","NP ","YES ",42
@@ -3074,8 +3074,8 @@
 "6","06-145 Eielson ","State House","6","REP ","Talerico, David M.  ",312
 "6","06-145 Eielson ","State House","6","DEM ","Land, Jason T.  ",68
 "6","06-145 Eielson ","State House","6","NP ","Write-in 40 ",1
-"6","06-145 Eielson ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",301
-"6","06-145 Eielson ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",91
+"6","06-145 Eielson ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",301
+"6","06-145 Eielson ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",91
 "6","06-145 Eielson ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",125
 "6","06-145 Eielson ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",245
 "6","06-145 Eielson ","Supreme Crt-Justice Bolger ","","NP ","YES ",181
@@ -3122,8 +3122,8 @@
 "6","06-150 Fox ","State House","6","REP ","Talerico, David M.  ",162
 "6","06-150 Fox ","State House","6","DEM ","Land, Jason T.  ",45
 "6","06-150 Fox ","State House","6","NP ","Write-in 40 ",3
-"6","06-150 Fox ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",106
-"6","06-150 Fox ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",118
+"6","06-150 Fox ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",106
+"6","06-150 Fox ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",118
 "6","06-150 Fox ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",59
 "6","06-150 Fox ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",154
 "6","06-150 Fox ","Supreme Crt-Justice Bolger ","","NP ","YES ",84
@@ -3170,8 +3170,8 @@
 "6","06-155 Moose Creek ","State House","6","REP ","Talerico, David M.  ",160
 "6","06-155 Moose Creek ","State House","6","DEM ","Land, Jason T.  ",43
 "6","06-155 Moose Creek ","State House","6","NP ","Write-in 40 ",0
-"6","06-155 Moose Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",123
-"6","06-155 Moose Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",84
+"6","06-155 Moose Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",123
+"6","06-155 Moose Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",84
 "6","06-155 Moose Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",64
 "6","06-155 Moose Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",138
 "6","06-155 Moose Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",108
@@ -3218,8 +3218,8 @@
 "6","06-160 Salcha ","State House","6","REP ","Talerico, David M.  ",358
 "6","06-160 Salcha ","State House","6","DEM ","Land, Jason T.  ",106
 "6","06-160 Salcha ","State House","6","NP ","Write-in 40 ",4
-"6","06-160 Salcha ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",260
-"6","06-160 Salcha ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",213
+"6","06-160 Salcha ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",260
+"6","06-160 Salcha ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",213
 "6","06-160 Salcha ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",130
 "6","06-160 Salcha ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",332
 "6","06-160 Salcha ","Supreme Crt-Justice Bolger ","","NP ","YES ",234
@@ -3266,8 +3266,8 @@
 "6","06-170 Steele Creek ","State House","6","REP ","Talerico, David M.  ",309
 "6","06-170 Steele Creek ","State House","6","DEM ","Land, Jason T.  ",147
 "6","06-170 Steele Creek ","State House","6","NP ","Write-in 40 ",3
-"6","06-170 Steele Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",303
-"6","06-170 Steele Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",173
+"6","06-170 Steele Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",303
+"6","06-170 Steele Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",173
 "6","06-170 Steele Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",173
 "6","06-170 Steele Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",287
 "6","06-170 Steele Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",258
@@ -3314,8 +3314,8 @@
 "6","06-180 Two Rivers ","State House","6","REP ","Talerico, David M.  ",348
 "6","06-180 Two Rivers ","State House","6","DEM ","Land, Jason T.  ",137
 "6","06-180 Two Rivers ","State House","6","NP ","Write-in 40 ",4
-"6","06-180 Two Rivers ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",308
-"6","06-180 Two Rivers ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",200
+"6","06-180 Two Rivers ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",308
+"6","06-180 Two Rivers ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",200
 "6","06-180 Two Rivers ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",179
 "6","06-180 Two Rivers ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",318
 "6","06-180 Two Rivers ","Supreme Crt-Justice Bolger ","","NP ","YES ",237
@@ -3364,8 +3364,8 @@
 "7","07-100 Lakes No. 1 ","State House","7","REP ","Sullivan-Leonard, Co ",404
 "7","07-100 Lakes No. 1 ","State House","7","DEM ","Olson, Sherie A.  ",112
 "7","07-100 Lakes No. 1 ","State House","7","NP ","Write-in 30 ",6
-"7","07-100 Lakes No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",286
-"7","07-100 Lakes No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",287
+"7","07-100 Lakes No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",286
+"7","07-100 Lakes No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",287
 "7","07-100 Lakes No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",191
 "7","07-100 Lakes No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",363
 "7","07-100 Lakes No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",219
@@ -3434,8 +3434,8 @@
 "7","07-105 Pioneer Peak ","State House","7","REP ","Sullivan-Leonard, Co ",308
 "7","07-105 Pioneer Peak ","State House","7","DEM ","Olson, Sherie A.  ",66
 "7","07-105 Pioneer Peak ","State House","7","NP ","Write-in 30 ",5
-"7","07-105 Pioneer Peak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",199
-"7","07-105 Pioneer Peak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",194
+"7","07-105 Pioneer Peak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",199
+"7","07-105 Pioneer Peak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",194
 "7","07-105 Pioneer Peak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",134
 "7","07-105 Pioneer Peak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",252
 "7","07-105 Pioneer Peak ","Supreme Crt-Justice Bolger ","","NP ","YES ",151
@@ -3504,8 +3504,8 @@
 "7","07-110 Schrock ","State House","7","REP ","Sullivan-Leonard, Co ",421
 "7","07-110 Schrock ","State House","7","DEM ","Olson, Sherie A.  ",146
 "7","07-110 Schrock ","State House","7","NP ","Write-in 30 ",2
-"7","07-110 Schrock ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",332
-"7","07-110 Schrock ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",279
+"7","07-110 Schrock ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",332
+"7","07-110 Schrock ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",279
 "7","07-110 Schrock ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",199
 "7","07-110 Schrock ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",389
 "7","07-110 Schrock ","Supreme Crt-Justice Bolger ","","NP ","YES ",224
@@ -3574,8 +3574,8 @@
 "7","07-115 Wasilla Lake ","State House","7","REP ","Sullivan-Leonard, Co ",327
 "7","07-115 Wasilla Lake ","State House","7","DEM ","Olson, Sherie A.  ",97
 "7","07-115 Wasilla Lake ","State House","7","NP ","Write-in 30 ",4
-"7","07-115 Wasilla Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",260
-"7","07-115 Wasilla Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",196
+"7","07-115 Wasilla Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",260
+"7","07-115 Wasilla Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",196
 "7","07-115 Wasilla Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",159
 "7","07-115 Wasilla Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",290
 "7","07-115 Wasilla Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",189
@@ -3644,8 +3644,8 @@
 "7","07-120 Wasilla No. 1 ","State House","7","REP ","Sullivan-Leonard, Co ",578
 "7","07-120 Wasilla No. 1 ","State House","7","DEM ","Olson, Sherie A.  ",206
 "7","07-120 Wasilla No. 1 ","State House","7","NP ","Write-in 30 ",18
-"7","07-120 Wasilla No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",470
-"7","07-120 Wasilla No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",402
+"7","07-120 Wasilla No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",470
+"7","07-120 Wasilla No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",402
 "7","07-120 Wasilla No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",286
 "7","07-120 Wasilla No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",558
 "7","07-120 Wasilla No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",328
@@ -3714,8 +3714,8 @@
 "7","07-125 Wasilla No. 2 ","State House","7","REP ","Sullivan-Leonard, Co ",698
 "7","07-125 Wasilla No. 2 ","State House","7","DEM ","Olson, Sherie A.  ",174
 "7","07-125 Wasilla No. 2 ","State House","7","NP ","Write-in 30 ",6
-"7","07-125 Wasilla No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",480
-"7","07-125 Wasilla No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",458
+"7","07-125 Wasilla No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",480
+"7","07-125 Wasilla No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",458
 "7","07-125 Wasilla No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",272
 "7","07-125 Wasilla No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",629
 "7","07-125 Wasilla No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",352
@@ -3784,8 +3784,8 @@
 "7","07-130 Foothills ","State House","7","REP ","Sullivan-Leonard, Co ",329
 "7","07-130 Foothills ","State House","7","DEM ","Olson, Sherie A.  ",60
 "7","07-130 Foothills ","State House","7","NP ","Write-in 30 ",2
-"7","07-130 Foothills ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",211
-"7","07-130 Foothills ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",211
+"7","07-130 Foothills ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",211
+"7","07-130 Foothills ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",211
 "7","07-130 Foothills ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",125
 "7","07-130 Foothills ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",279
 "7","07-130 Foothills ","Supreme Crt-Justice Bolger ","","NP ","YES ",137
@@ -3854,8 +3854,8 @@
 "8","08-130 Meadow Lakes No. 1 ","State House","8","DEM ","Jones, Gregory I.  ",77
 "8","08-130 Meadow Lakes No. 1 ","State House","8","REP ","Neuman, Mark A.  ",312
 "8","08-130 Meadow Lakes No. 1 ","State House","8","NP ","Write-in 30 ",1
-"8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",215
-"8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",193
+"8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",215
+"8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",193
 "8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",132
 "8","08-130 Meadow Lakes No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",261
 "8","08-130 Meadow Lakes No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",163
@@ -3924,8 +3924,8 @@
 "8","08-135 Meadow Lakes No. 2 ","State House","8","DEM ","Jones, Gregory I.  ",155
 "8","08-135 Meadow Lakes No. 2 ","State House","8","REP ","Neuman, Mark A.  ",639
 "8","08-135 Meadow Lakes No. 2 ","State House","8","NP ","Write-in 30 ",5
-"8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",379
-"8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",460
+"8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",379
+"8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",460
 "8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",233
 "8","08-135 Meadow Lakes No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",584
 "8","08-135 Meadow Lakes No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",291
@@ -3994,8 +3994,8 @@
 "8","08-140 Knik Goose Bay No. 1 ","State House","8","DEM ","Jones, Gregory I.  ",148
 "8","08-140 Knik Goose Bay No. 1 ","State House","8","REP ","Neuman, Mark A.  ",739
 "8","08-140 Knik Goose Bay No. 1 ","State House","8","NP ","Write-in 30 ",4
-"8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",481
-"8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",468
+"8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",481
+"8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",468
 "8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",301
 "8","08-140 Knik Goose Bay No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",615
 "8","08-140 Knik Goose Bay No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",344
@@ -4064,8 +4064,8 @@
 "8","08-145 Knik Goose Bay No. 2 ","State House","8","DEM ","Jones, Gregory I.  ",98
 "8","08-145 Knik Goose Bay No. 2 ","State House","8","REP ","Neuman, Mark A.  ",538
 "8","08-145 Knik Goose Bay No. 2 ","State House","8","NP ","Write-in 30 ",5
-"8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",351
-"8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",306
+"8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",351
+"8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",306
 "8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",216
 "8","08-145 Knik Goose Bay No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",424
 "8","08-145 Knik Goose Bay No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",246
@@ -4134,8 +4134,8 @@
 "8","08-150 Knik Goose Bay No. 3 ","State House","8","DEM ","Jones, Gregory I.  ",167
 "8","08-150 Knik Goose Bay No. 3 ","State House","8","REP ","Neuman, Mark A.  ",712
 "8","08-150 Knik Goose Bay No. 3 ","State House","8","NP ","Write-in 30 ",11
-"8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",469
-"8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",458
+"8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",469
+"8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",458
 "8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",281
 "8","08-150 Knik Goose Bay No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",628
 "8","08-150 Knik Goose Bay No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",342
@@ -4204,8 +4204,8 @@
 "8","08-155 Big Lake ","State House","8","DEM ","Jones, Gregory I.  ",171
 "8","08-155 Big Lake ","State House","8","REP ","Neuman, Mark A.  ",902
 "8","08-155 Big Lake ","State House","8","NP ","Write-in 30 ",14
-"8","08-155 Big Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",511
-"8","08-155 Big Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",626
+"8","08-155 Big Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",511
+"8","08-155 Big Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",626
 "8","08-155 Big Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",308
 "8","08-155 Big Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",796
 "8","08-155 Big Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",357
@@ -4272,8 +4272,8 @@
 "9","09-600 Big Delta ","State House","9","REP ","Rauscher, George ",574
 "9","09-600 Big Delta ","State House","9","CON ","Goode, Pamela ",397
 "9","09-600 Big Delta ","State House","9","NP ","Write-in 30 ",24
-"9","09-600 Big Delta ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",553
-"9","09-600 Big Delta ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",454
+"9","09-600 Big Delta ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",553
+"9","09-600 Big Delta ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",454
 "9","09-600 Big Delta ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",288
 "9","09-600 Big Delta ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",702
 "9","09-600 Big Delta ","Supreme Crt-Justice Bolger ","","NP ","YES ",402
@@ -4320,8 +4320,8 @@
 "9","09-608 Delta Junction ","State House","9","REP ","Rauscher, George ",190
 "9","09-608 Delta Junction ","State House","9","CON ","Goode, Pamela ",115
 "9","09-608 Delta Junction ","State House","9","NP ","Write-in 30 ",10
-"9","09-608 Delta Junction ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",182
-"9","09-608 Delta Junction ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",144
+"9","09-608 Delta Junction ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",182
+"9","09-608 Delta Junction ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",144
 "9","09-608 Delta Junction ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",90
 "9","09-608 Delta Junction ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",232
 "9","09-608 Delta Junction ","Supreme Crt-Justice Bolger ","","NP ","YES ",130
@@ -4368,8 +4368,8 @@
 "9","09-622 Farm Loop ","State House","9","REP ","Rauscher, George ",566
 "9","09-622 Farm Loop ","State House","9","CON ","Goode, Pamela ",309
 "9","09-622 Farm Loop ","State House","9","NP ","Write-in 30 ",20
-"9","09-622 Farm Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",464
-"9","09-622 Farm Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",458
+"9","09-622 Farm Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",464
+"9","09-622 Farm Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",458
 "9","09-622 Farm Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",283
 "9","09-622 Farm Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",616
 "9","09-622 Farm Loop ","Supreme Crt-Justice Bolger ","","NP ","YES ",348
@@ -4436,8 +4436,8 @@
 "9","09-628 Fishhook ","State House","9","REP ","Rauscher, George ",662
 "9","09-628 Fishhook ","State House","9","CON ","Goode, Pamela ",442
 "9","09-628 Fishhook ","State House","9","NP ","Write-in 30 ",24
-"9","09-628 Fishhook ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",627
-"9","09-628 Fishhook ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",556
+"9","09-628 Fishhook ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",627
+"9","09-628 Fishhook ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",556
 "9","09-628 Fishhook ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",391
 "9","09-628 Fishhook ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",752
 "9","09-628 Fishhook ","Supreme Crt-Justice Bolger ","","NP ","YES ",445
@@ -4504,8 +4504,8 @@
 "9","09-632 Glennallen ","State House","9","REP ","Rauscher, George ",123
 "9","09-632 Glennallen ","State House","9","CON ","Goode, Pamela ",57
 "9","09-632 Glennallen ","State House","9","NP ","Write-in 30 ",3
-"9","09-632 Glennallen ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",88
-"9","09-632 Glennallen ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",100
+"9","09-632 Glennallen ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",88
+"9","09-632 Glennallen ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",100
 "9","09-632 Glennallen ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",48
 "9","09-632 Glennallen ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",138
 "9","09-632 Glennallen ","Supreme Crt-Justice Bolger ","","NP ","YES ",62
@@ -4572,8 +4572,8 @@
 "9","09-640 Sheep Mountain ","State House","9","REP ","Rauscher, George ",61
 "9","09-640 Sheep Mountain ","State House","9","CON ","Goode, Pamela ",46
 "9","09-640 Sheep Mountain ","State House","9","NP ","Write-in 30 ",3
-"9","09-640 Sheep Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",59
-"9","09-640 Sheep Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",60
+"9","09-640 Sheep Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",59
+"9","09-640 Sheep Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",60
 "9","09-640 Sheep Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",40
 "9","09-640 Sheep Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",76
 "9","09-640 Sheep Mountain ","Supreme Crt-Justice Bolger ","","NP ","YES ",41
@@ -4640,8 +4640,8 @@
 "9","09-645 Sutton ","State House","9","REP ","Rauscher, George ",295
 "9","09-645 Sutton ","State House","9","CON ","Goode, Pamela ",122
 "9","09-645 Sutton ","State House","9","NP ","Write-in 30 ",7
-"9","09-645 Sutton ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",232
-"9","09-645 Sutton ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",201
+"9","09-645 Sutton ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",232
+"9","09-645 Sutton ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",201
 "9","09-645 Sutton ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",143
 "9","09-645 Sutton ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",277
 "9","09-645 Sutton ","Supreme Crt-Justice Bolger ","","NP ","YES ",168
@@ -4708,8 +4708,8 @@
 "9","09-650 Valdez No. 1 ","State House","9","REP ","Rauscher, George ",264
 "9","09-650 Valdez No. 1 ","State House","9","CON ","Goode, Pamela ",182
 "9","09-650 Valdez No. 1 ","State House","9","NP ","Write-in 30 ",5
-"9","09-650 Valdez No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",334
-"9","09-650 Valdez No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",155
+"9","09-650 Valdez No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",334
+"9","09-650 Valdez No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",155
 "9","09-650 Valdez No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",210
 "9","09-650 Valdez No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",264
 "9","09-650 Valdez No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",301
@@ -4776,8 +4776,8 @@
 "9","09-655 Valdez No. 2 ","State House","9","REP ","Rauscher, George ",145
 "9","09-655 Valdez No. 2 ","State House","9","CON ","Goode, Pamela ",107
 "9","09-655 Valdez No. 2 ","State House","9","NP ","Write-in 30 ",5
-"9","09-655 Valdez No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",177
-"9","09-655 Valdez No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",95
+"9","09-655 Valdez No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",177
+"9","09-655 Valdez No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",95
 "9","09-655 Valdez No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",113
 "9","09-655 Valdez No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",148
 "9","09-655 Valdez No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",158
@@ -4844,8 +4844,8 @@
 "9","09-660 Valdez No. 3 ","State House","9","REP ","Rauscher, George ",202
 "9","09-660 Valdez No. 3 ","State House","9","CON ","Goode, Pamela ",167
 "9","09-660 Valdez No. 3 ","State House","9","NP ","Write-in 30 ",10
-"9","09-660 Valdez No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",261
-"9","09-660 Valdez No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",145
+"9","09-660 Valdez No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",261
+"9","09-660 Valdez No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",145
 "9","09-660 Valdez No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",166
 "9","09-660 Valdez No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",217
 "9","09-660 Valdez No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",223
@@ -4912,8 +4912,8 @@
 "9","09-665 Whittier ","State House","9","REP ","Rauscher, George ",55
 "9","09-665 Whittier ","State House","9","CON ","Goode, Pamela ",36
 "9","09-665 Whittier ","State House","9","NP ","Write-in 30 ",1
-"9","09-665 Whittier ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",76
-"9","09-665 Whittier ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",28
+"9","09-665 Whittier ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",76
+"9","09-665 Whittier ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",28
 "9","09-665 Whittier ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",46
 "9","09-665 Whittier ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",52
 "9","09-665 Whittier ","Supreme Crt-Justice Bolger ","","NP ","YES ",48
@@ -4980,8 +4980,8 @@
 "10","10-005 Kings Lake ","State House","10","DEM ","Faye-Brazel, Patrici ",88
 "10","10-005 Kings Lake ","State House","10","REP ","Eastman, David ",292
 "10","10-005 Kings Lake ","State House","10","NP ","Write-in 30 ",0
-"10","10-005 Kings Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",213
-"10","10-005 Kings Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",177
+"10","10-005 Kings Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",213
+"10","10-005 Kings Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",177
 "10","10-005 Kings Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",123
 "10","10-005 Kings Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",258
 "10","10-005 Kings Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",167
@@ -5048,8 +5048,8 @@
 "10","10-010 Church ","State House","10","DEM ","Faye-Brazel, Patrici ",139
 "10","10-010 Church ","State House","10","REP ","Eastman, David ",512
 "10","10-010 Church ","State House","10","NP ","Write-in 30 ",3
-"10","10-010 Church ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",348
-"10","10-010 Church ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",319
+"10","10-010 Church ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",348
+"10","10-010 Church ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",319
 "10","10-010 Church ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",204
 "10","10-010 Church ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",444
 "10","10-010 Church ","Supreme Crt-Justice Bolger ","","NP ","YES ",265
@@ -5116,8 +5116,8 @@
 "10","10-015 Tanaina ","State House","10","DEM ","Faye-Brazel, Patrici ",159
 "10","10-015 Tanaina ","State House","10","REP ","Eastman, David ",658
 "10","10-015 Tanaina ","State House","10","NP ","Write-in 30 ",8
-"10","10-015 Tanaina ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",408
-"10","10-015 Tanaina ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",431
+"10","10-015 Tanaina ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",408
+"10","10-015 Tanaina ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",431
 "10","10-015 Tanaina ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",253
 "10","10-015 Tanaina ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",562
 "10","10-015 Tanaina ","Supreme Crt-Justice Bolger ","","NP ","YES ",314
@@ -5184,8 +5184,8 @@
 "10","10-020 Houston ","State House","10","DEM ","Faye-Brazel, Patrici ",104
 "10","10-020 Houston ","State House","10","REP ","Eastman, David ",397
 "10","10-020 Houston ","State House","10","NP ","Write-in 30 ",4
-"10","10-020 Houston ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",261
-"10","10-020 Houston ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",249
+"10","10-020 Houston ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",261
+"10","10-020 Houston ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",249
 "10","10-020 Houston ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",162
 "10","10-020 Houston ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",333
 "10","10-020 Houston ","Supreme Crt-Justice Bolger ","","NP ","YES ",159
@@ -5252,8 +5252,8 @@
 "10","10-025 Meadow Lakes No. 3 ","State House","10","DEM ","Faye-Brazel, Patrici ",75
 "10","10-025 Meadow Lakes No. 3 ","State House","10","REP ","Eastman, David ",320
 "10","10-025 Meadow Lakes No. 3 ","State House","10","NP ","Write-in 30 ",5
-"10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",213
-"10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",199
+"10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",213
+"10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",199
 "10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",116
 "10","10-025 Meadow Lakes No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",286
 "10","10-025 Meadow Lakes No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",149
@@ -5320,8 +5320,8 @@
 "10","10-030 Susitna ","State House","10","DEM ","Faye-Brazel, Patrici ",104
 "10","10-030 Susitna ","State House","10","REP ","Eastman, David ",321
 "10","10-030 Susitna ","State House","10","NP ","Write-in 30 ",5
-"10","10-030 Susitna ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",226
-"10","10-030 Susitna ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",214
+"10","10-030 Susitna ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",226
+"10","10-030 Susitna ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",214
 "10","10-030 Susitna ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",147
 "10","10-030 Susitna ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",272
 "10","10-030 Susitna ","Supreme Crt-Justice Bolger ","","NP ","YES ",172
@@ -5388,8 +5388,8 @@
 "10","10-035 Talkeetna ","State House","10","DEM ","Faye-Brazel, Patrici ",196
 "10","10-035 Talkeetna ","State House","10","REP ","Eastman, David ",138
 "10","10-035 Talkeetna ","State House","10","NP ","Write-in 30 ",1
-"10","10-035 Talkeetna ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",217
-"10","10-035 Talkeetna ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",129
+"10","10-035 Talkeetna ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",217
+"10","10-035 Talkeetna ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",129
 "10","10-035 Talkeetna ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",179
 "10","10-035 Talkeetna ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",154
 "10","10-035 Talkeetna ","Supreme Crt-Justice Bolger ","","NP ","YES ",162
@@ -5456,8 +5456,8 @@
 "10","10-040 Trapper Creek ","State House","10","DEM ","Faye-Brazel, Patrici ",35
 "10","10-040 Trapper Creek ","State House","10","REP ","Eastman, David ",110
 "10","10-040 Trapper Creek ","State House","10","NP ","Write-in 30 ",0
-"10","10-040 Trapper Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",75
-"10","10-040 Trapper Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",75
+"10","10-040 Trapper Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",75
+"10","10-040 Trapper Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",75
 "10","10-040 Trapper Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",49
 "10","10-040 Trapper Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",100
 "10","10-040 Trapper Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",56
@@ -5524,8 +5524,8 @@
 "10","10-045 Willow ","State House","10","DEM ","Faye-Brazel, Patrici ",207
 "10","10-045 Willow ","State House","10","REP ","Eastman, David ",582
 "10","10-045 Willow ","State House","10","NP ","Write-in 30 ",8
-"10","10-045 Willow ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",432
-"10","10-045 Willow ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",394
+"10","10-045 Willow ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",432
+"10","10-045 Willow ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",394
 "10","10-045 Willow ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",242
 "10","10-045 Willow ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",569
 "10","10-045 Willow ","Supreme Crt-Justice Bolger ","","NP ","YES ",311
@@ -5592,8 +5592,8 @@
 "10","10-050 Meadow Lakes No. 4 ","State House","10","DEM ","Faye-Brazel, Patrici ",33
 "10","10-050 Meadow Lakes No. 4 ","State House","10","REP ","Eastman, David ",137
 "10","10-050 Meadow Lakes No. 4 ","State House","10","NP ","Write-in 30 ",0
-"10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",100
-"10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",79
+"10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",100
+"10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",79
 "10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",58
 "10","10-050 Meadow Lakes No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",112
 "10","10-050 Meadow Lakes No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",52
@@ -5660,8 +5660,8 @@
 "10","10-055 Lakes No. 2 ","State House","10","DEM ","Faye-Brazel, Patrici ",78
 "10","10-055 Lakes No. 2 ","State House","10","REP ","Eastman, David ",270
 "10","10-055 Lakes No. 2 ","State House","10","NP ","Write-in 30 ",2
-"10","10-055 Lakes No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",187
-"10","10-055 Lakes No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",174
+"10","10-055 Lakes No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",187
+"10","10-055 Lakes No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",174
 "10","10-055 Lakes No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",136
 "10","10-055 Lakes No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",218
 "10","10-055 Lakes No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",135
@@ -5731,8 +5731,8 @@
 "11","11-055 Walby ","State House","11","REP ","Johnson, DeLena ",569
 "11","11-055 Walby ","State House","11","NA ","Verrall, Bert ",210
 "11","11-055 Walby ","State House","11","NP ","Write-in 30 ",0
-"11","11-055 Walby ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",453
-"11","11-055 Walby ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",359
+"11","11-055 Walby ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",453
+"11","11-055 Walby ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",359
 "11","11-055 Walby ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",279
 "11","11-055 Walby ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",513
 "11","11-055 Walby ","Supreme Crt-Justice Bolger ","","NP ","YES ",331
@@ -5802,8 +5802,8 @@
 "11","11-060 Greater Palmer ","State House","11","REP ","Johnson, DeLena ",458
 "11","11-060 Greater Palmer ","State House","11","NA ","Verrall, Bert ",197
 "11","11-060 Greater Palmer ","State House","11","NP ","Write-in 30 ",4
-"11","11-060 Greater Palmer ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",370
-"11","11-060 Greater Palmer ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",312
+"11","11-060 Greater Palmer ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",370
+"11","11-060 Greater Palmer ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",312
 "11","11-060 Greater Palmer ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",245
 "11","11-060 Greater Palmer ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",410
 "11","11-060 Greater Palmer ","Supreme Crt-Justice Bolger ","","NP ","YES ",320
@@ -5873,8 +5873,8 @@
 "11","11-065 Mat-Su Campus ","State House","11","REP ","Johnson, DeLena ",293
 "11","11-065 Mat-Su Campus ","State House","11","NA ","Verrall, Bert ",110
 "11","11-065 Mat-Su Campus ","State House","11","NP ","Write-in 30 ",2
-"11","11-065 Mat-Su Campus ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",221
-"11","11-065 Mat-Su Campus ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",197
+"11","11-065 Mat-Su Campus ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",221
+"11","11-065 Mat-Su Campus ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",197
 "11","11-065 Mat-Su Campus ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",162
 "11","11-065 Mat-Su Campus ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",249
 "11","11-065 Mat-Su Campus ","Supreme Crt-Justice Bolger ","","NP ","YES ",178
@@ -5944,8 +5944,8 @@
 "11","11-070 Palmer City No. 1 ","State House","11","REP ","Johnson, DeLena ",426
 "11","11-070 Palmer City No. 1 ","State House","11","NA ","Verrall, Bert ",273
 "11","11-070 Palmer City No. 1 ","State House","11","NP ","Write-in 30 ",5
-"11","11-070 Palmer City No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",427
-"11","11-070 Palmer City No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",314
+"11","11-070 Palmer City No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",427
+"11","11-070 Palmer City No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",314
 "11","11-070 Palmer City No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",302
 "11","11-070 Palmer City No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",422
 "11","11-070 Palmer City No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",329
@@ -6015,8 +6015,8 @@
 "11","11-075 Palmer City No. 2 ","State House","11","REP ","Johnson, DeLena ",433
 "11","11-075 Palmer City No. 2 ","State House","11","NA ","Verrall, Bert ",255
 "11","11-075 Palmer City No. 2 ","State House","11","NP ","Write-in 30 ",2
-"11","11-075 Palmer City No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",389
-"11","11-075 Palmer City No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",327
+"11","11-075 Palmer City No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",389
+"11","11-075 Palmer City No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",327
 "11","11-075 Palmer City No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",286
 "11","11-075 Palmer City No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",409
 "11","11-075 Palmer City No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",313
@@ -6086,8 +6086,8 @@
 "11","11-085 Trunk ","State House","11","REP ","Johnson, DeLena ",436
 "11","11-085 Trunk ","State House","11","NA ","Verrall, Bert ",151
 "11","11-085 Trunk ","State House","11","NP ","Write-in 30 ",0
-"11","11-085 Trunk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",339
-"11","11-085 Trunk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",272
+"11","11-085 Trunk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",339
+"11","11-085 Trunk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",272
 "11","11-085 Trunk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",194
 "11","11-085 Trunk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",396
 "11","11-085 Trunk ","Supreme Crt-Justice Bolger ","","NP ","YES ",214
@@ -6157,8 +6157,8 @@
 "11","11-090 Seward Meridian ","State House","11","REP ","Johnson, DeLena ",275
 "11","11-090 Seward Meridian ","State House","11","NA ","Verrall, Bert ",107
 "11","11-090 Seward Meridian ","State House","11","NP ","Write-in 30 ",2
-"11","11-090 Seward Meridian ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",212
-"11","11-090 Seward Meridian ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",190
+"11","11-090 Seward Meridian ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",212
+"11","11-090 Seward Meridian ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",190
 "11","11-090 Seward Meridian ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",139
 "11","11-090 Seward Meridian ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",255
 "11","11-090 Seward Meridian ","Supreme Crt-Justice Bolger ","","NP ","YES ",141
@@ -6228,8 +6228,8 @@
 "11","11-095 Springer Loop ","State House","11","REP ","Johnson, DeLena ",469
 "11","11-095 Springer Loop ","State House","11","NA ","Verrall, Bert ",228
 "11","11-095 Springer Loop ","State House","11","NP ","Write-in 30 ",2
-"11","11-095 Springer Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",380
-"11","11-095 Springer Loop ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",344
+"11","11-095 Springer Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",380
+"11","11-095 Springer Loop ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",344
 "11","11-095 Springer Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",254
 "11","11-095 Springer Loop ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",437
 "11","11-095 Springer Loop ","Supreme Crt-Justice Bolger ","","NP ","YES ",303
@@ -6299,8 +6299,8 @@
 "11","11-099 Lazy Mountain ","State House","11","REP ","Johnson, DeLena ",353
 "11","11-099 Lazy Mountain ","State House","11","NA ","Verrall, Bert ",170
 "11","11-099 Lazy Mountain ","State House","11","NP ","Write-in 30 ",4
-"11","11-099 Lazy Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",300
-"11","11-099 Lazy Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",256
+"11","11-099 Lazy Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",300
+"11","11-099 Lazy Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",256
 "11","11-099 Lazy Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",205
 "11","11-099 Lazy Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",336
 "11","11-099 Lazy Mountain ","Supreme Crt-Justice Bolger ","","NP ","YES ",216
@@ -6371,8 +6371,8 @@
 "12","12-200 Fairview No. 1 ","State House","12","CON ","Perry, Karen ",39
 "12","12-200 Fairview No. 1 ","State House","12","DEM ","Wehmhoff, Gretchen L ",67
 "12","12-200 Fairview No. 1 ","State House","12","NP ","Write-in 40 ",0
-"12","12-200 Fairview No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",225
-"12","12-200 Fairview No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",211
+"12","12-200 Fairview No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",225
+"12","12-200 Fairview No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",211
 "12","12-200 Fairview No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",124
 "12","12-200 Fairview No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",299
 "12","12-200 Fairview No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",158
@@ -6443,8 +6443,8 @@
 "12","12-205 Fairview No. 2 ","State House","12","CON ","Perry, Karen ",66
 "12","12-205 Fairview No. 2 ","State House","12","DEM ","Wehmhoff, Gretchen L ",90
 "12","12-205 Fairview No. 2 ","State House","12","NP ","Write-in 40 ",2
-"12","12-205 Fairview No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",310
-"12","12-205 Fairview No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",227
+"12","12-205 Fairview No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",310
+"12","12-205 Fairview No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",227
 "12","12-205 Fairview No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",168
 "12","12-205 Fairview No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",339
 "12","12-205 Fairview No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",205
@@ -6515,8 +6515,8 @@
 "12","12-210 Snowshoe ","State House","12","CON ","Perry, Karen ",101
 "12","12-210 Snowshoe ","State House","12","DEM ","Wehmhoff, Gretchen L ",147
 "12","12-210 Snowshoe ","State House","12","NP ","Write-in 40 ",2
-"12","12-210 Snowshoe ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",465
-"12","12-210 Snowshoe ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",429
+"12","12-210 Snowshoe ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",465
+"12","12-210 Snowshoe ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",429
 "12","12-210 Snowshoe ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",273
 "12","12-210 Snowshoe ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",598
 "12","12-210 Snowshoe ","Supreme Crt-Justice Bolger ","","NP ","YES ",340
@@ -6587,8 +6587,8 @@
 "12","12-220 Butte ","State House","12","CON ","Perry, Karen ",161
 "12","12-220 Butte ","State House","12","DEM ","Wehmhoff, Gretchen L ",304
 "12","12-220 Butte ","State House","12","NP ","Write-in 40 ",5
-"12","12-220 Butte ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",690
-"12","12-220 Butte ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",646
+"12","12-220 Butte ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",690
+"12","12-220 Butte ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",646
 "12","12-220 Butte ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",467
 "12","12-220 Butte ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",842
 "12","12-220 Butte ","Supreme Crt-Justice Bolger ","","NP ","YES ",528
@@ -6659,8 +6659,8 @@
 "12","12-225 Eklutna ","State House","12","CON ","Perry, Karen ",75
 "12","12-225 Eklutna ","State House","12","DEM ","Wehmhoff, Gretchen L ",221
 "12","12-225 Eklutna ","State House","12","NP ","Write-in 40 ",3
-"12","12-225 Eklutna ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",371
-"12","12-225 Eklutna ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",367
+"12","12-225 Eklutna ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",371
+"12","12-225 Eklutna ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",367
 "12","12-225 Eklutna ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",253
 "12","12-225 Eklutna ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",468
 "12","12-225 Eklutna ","Supreme Crt-Justice Bolger ","","NP ","YES ",343
@@ -6731,8 +6731,8 @@
 "12","12-230 Peters Creek No. 1 ","State House","12","CON ","Perry, Karen ",135
 "12","12-230 Peters Creek No. 1 ","State House","12","DEM ","Wehmhoff, Gretchen L ",264
 "12","12-230 Peters Creek No. 1 ","State House","12","NP ","Write-in 40 ",2
-"12","12-230 Peters Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",576
-"12","12-230 Peters Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",553
+"12","12-230 Peters Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",576
+"12","12-230 Peters Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",553
 "12","12-230 Peters Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",349
 "12","12-230 Peters Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",750
 "12","12-230 Peters Creek No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",486
@@ -6803,8 +6803,8 @@
 "12","12-233 Peters Creek No. 2 ","State House","12","CON ","Perry, Karen ",75
 "12","12-233 Peters Creek No. 2 ","State House","12","DEM ","Wehmhoff, Gretchen L ",137
 "12","12-233 Peters Creek No. 2 ","State House","12","NP ","Write-in 40 ",2
-"12","12-233 Peters Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",245
-"12","12-233 Peters Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",291
+"12","12-233 Peters Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",245
+"12","12-233 Peters Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",291
 "12","12-233 Peters Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",171
 "12","12-233 Peters Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",356
 "12","12-233 Peters Creek No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",220
@@ -6870,8 +6870,8 @@
 "13","13-235 Chugiak ","U.S. House","1","NP ","Write-in 50 ",0
 "13","13-235 Chugiak ","State House","13","REP ","Saddler, Dan ",442
 "13","13-235 Chugiak ","State House","13","NP ","Write-in 20 ",21
-"13","13-235 Chugiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",282
-"13","13-235 Chugiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",257
+"13","13-235 Chugiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",282
+"13","13-235 Chugiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",257
 "13","13-235 Chugiak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",175
 "13","13-235 Chugiak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",347
 "13","13-235 Chugiak ","Supreme Crt-Justice Bolger ","","NP ","YES ",221
@@ -6937,8 +6937,8 @@
 "13","13-240 Fire Lake ","U.S. House","1","NP ","Write-in 50 ",3
 "13","13-240 Fire Lake ","State House","13","REP ","Saddler, Dan ",740
 "13","13-240 Fire Lake ","State House","13","NP ","Write-in 20 ",38
-"13","13-240 Fire Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",503
-"13","13-240 Fire Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",367
+"13","13-240 Fire Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",503
+"13","13-240 Fire Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",367
 "13","13-240 Fire Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",289
 "13","13-240 Fire Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",540
 "13","13-240 Fire Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",398
@@ -7004,8 +7004,8 @@
 "13","13-245 JBER No. 1 ","U.S. House","1","NP ","Write-in 50 ",4
 "13","13-245 JBER No. 1 ","State House","13","REP ","Saddler, Dan ",468
 "13","13-245 JBER No. 1 ","State House","13","NP ","Write-in 20 ",22
-"13","13-245 JBER No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",415
-"13","13-245 JBER No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",138
+"13","13-245 JBER No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",415
+"13","13-245 JBER No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",138
 "13","13-245 JBER No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",183
 "13","13-245 JBER No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",344
 "13","13-245 JBER No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",287
@@ -7071,8 +7071,8 @@
 "13","13-250 Downtown Eagle River No. 1 ","U.S. House","1","NP ","Write-in 50 ",1
 "13","13-250 Downtown Eagle River No. 1 ","State House","13","REP ","Saddler, Dan ",795
 "13","13-250 Downtown Eagle River No. 1 ","State House","13","NP ","Write-in 20 ",46
-"13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",612
-"13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",393
+"13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",612
+"13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",393
 "13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",365
 "13","13-250 Downtown Eagle River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",593
 "13","13-250 Downtown Eagle River No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",472
@@ -7138,8 +7138,8 @@
 "13","13-255 Chugach Park No. 1 ","U.S. House","1","NP ","Write-in 50 ",3
 "13","13-255 Chugach Park No. 1 ","State House","13","REP ","Saddler, Dan ",569
 "13","13-255 Chugach Park No. 1 ","State House","13","NP ","Write-in 20 ",38
-"13","13-255 Chugach Park No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",375
-"13","13-255 Chugach Park No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",349
+"13","13-255 Chugach Park No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",375
+"13","13-255 Chugach Park No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",349
 "13","13-255 Chugach Park No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",264
 "13","13-255 Chugach Park No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",438
 "13","13-255 Chugach Park No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",320
@@ -7205,8 +7205,8 @@
 "13","13-260 Centennial Park ","U.S. House","1","NP ","Write-in 50 ",0
 "13","13-260 Centennial Park ","State House","13","REP ","Saddler, Dan ",84
 "13","13-260 Centennial Park ","State House","13","NP ","Write-in 20 ",5
-"13","13-260 Centennial Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",105
-"13","13-260 Centennial Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",28
+"13","13-260 Centennial Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",105
+"13","13-260 Centennial Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",28
 "13","13-260 Centennial Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",76
 "13","13-260 Centennial Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",55
 "13","13-260 Centennial Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",75
@@ -7273,8 +7273,8 @@
 "14","14-940 Downtown Eagle River No. 2 ","State House","14","NA ","Hackenmueller, Joe ",318
 "14","14-940 Downtown Eagle River No. 2 ","State House","14","REP ","Reinbold, Lora ",515
 "14","14-940 Downtown Eagle River No. 2 ","State House","14","NP ","Write-in 30 ",1
-"14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",495
-"14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",356
+"14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",495
+"14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",356
 "14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",301
 "14","14-940 Downtown Eagle River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",526
 "14","14-940 Downtown Eagle River No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",415
@@ -7341,8 +7341,8 @@
 "14","14-945 Meadow Creek No. 1 ","State House","14","NA ","Hackenmueller, Joe ",233
 "14","14-945 Meadow Creek No. 1 ","State House","14","REP ","Reinbold, Lora ",384
 "14","14-945 Meadow Creek No. 1 ","State House","14","NP ","Write-in 30 ",4
-"14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",335
-"14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",299
+"14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",335
+"14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",299
 "14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",200
 "14","14-945 Meadow Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",411
 "14","14-945 Meadow Creek No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",254
@@ -7409,8 +7409,8 @@
 "14","14-950 Meadow Creek No. 2 ","State House","14","NA ","Hackenmueller, Joe ",354
 "14","14-950 Meadow Creek No. 2 ","State House","14","REP ","Reinbold, Lora ",548
 "14","14-950 Meadow Creek No. 2 ","State House","14","NP ","Write-in 30 ",7
-"14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",508
-"14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",402
+"14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",508
+"14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",402
 "14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",310
 "14","14-950 Meadow Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",572
 "14","14-950 Meadow Creek No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",408
@@ -7477,8 +7477,8 @@
 "14","14-955 Eagle River No. 1 ","State House","14","NA ","Hackenmueller, Joe ",165
 "14","14-955 Eagle River No. 1 ","State House","14","REP ","Reinbold, Lora ",257
 "14","14-955 Eagle River No. 1 ","State House","14","NP ","Write-in 30 ",1
-"14","14-955 Eagle River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",242
-"14","14-955 Eagle River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",189
+"14","14-955 Eagle River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",242
+"14","14-955 Eagle River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",189
 "14","14-955 Eagle River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",167
 "14","14-955 Eagle River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",247
 "14","14-955 Eagle River No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",204
@@ -7545,8 +7545,8 @@
 "14","14-960 Eagle River No. 2 ","State House","14","NA ","Hackenmueller, Joe ",441
 "14","14-960 Eagle River No. 2 ","State House","14","REP ","Reinbold, Lora ",627
 "14","14-960 Eagle River No. 2 ","State House","14","NP ","Write-in 30 ",8
-"14","14-960 Eagle River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",636
-"14","14-960 Eagle River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",451
+"14","14-960 Eagle River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",636
+"14","14-960 Eagle River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",451
 "14","14-960 Eagle River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",395
 "14","14-960 Eagle River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",661
 "14","14-960 Eagle River No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",577
@@ -7613,8 +7613,8 @@
 "14","14-965 Chugach Park No. 2 ","State House","14","NA ","Hackenmueller, Joe ",661
 "14","14-965 Chugach Park No. 2 ","State House","14","REP ","Reinbold, Lora ",795
 "14","14-965 Chugach Park No. 2 ","State House","14","NP ","Write-in 30 ",5
-"14","14-965 Chugach Park No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",824
-"14","14-965 Chugach Park No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",640
+"14","14-965 Chugach Park No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",824
+"14","14-965 Chugach Park No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",640
 "14","14-965 Chugach Park No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",541
 "14","14-965 Chugach Park No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",887
 "14","14-965 Chugach Park No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",753
@@ -7681,8 +7681,8 @@
 "14","14-970 Hiland ","State House","14","NA ","Hackenmueller, Joe ",300
 "14","14-970 Hiland ","State House","14","REP ","Reinbold, Lora ",555
 "14","14-970 Hiland ","State House","14","NP ","Write-in 30 ",1
-"14","14-970 Hiland ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",493
-"14","14-970 Hiland ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",379
+"14","14-970 Hiland ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",493
+"14","14-970 Hiland ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",379
 "14","14-970 Hiland ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",319
 "14","14-970 Hiland ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",530
 "14","14-970 Hiland ","Supreme Crt-Justice Bolger ","","NP ","YES ",433
@@ -7752,8 +7752,8 @@
 "15","15-300 JBER No. 2 ","State House","15","REP ","LeDoux, Gabrielle ",356
 "15","15-300 JBER No. 2 ","State House","15","DEM ","McCormack, Patrick M ",122
 "15","15-300 JBER No. 2 ","State House","15","NP ","Write-in 30 ",3
-"15","15-300 JBER No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",374
-"15","15-300 JBER No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",126
+"15","15-300 JBER No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",374
+"15","15-300 JBER No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",126
 "15","15-300 JBER No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",161
 "15","15-300 JBER No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",315
 "15","15-300 JBER No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",236
@@ -7823,8 +7823,8 @@
 "15","15-305 Creekside Park ","State House","15","REP ","LeDoux, Gabrielle ",478
 "15","15-305 Creekside Park ","State House","15","DEM ","McCormack, Patrick M ",252
 "15","15-305 Creekside Park ","State House","15","NP ","Write-in 30 ",3
-"15","15-305 Creekside Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",430
-"15","15-305 Creekside Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",316
+"15","15-305 Creekside Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",430
+"15","15-305 Creekside Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",316
 "15","15-305 Creekside Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",295
 "15","15-305 Creekside Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",436
 "15","15-305 Creekside Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",367
@@ -7894,8 +7894,8 @@
 "15","15-310 Muldoon No. 1 ","State House","15","REP ","LeDoux, Gabrielle ",354
 "15","15-310 Muldoon No. 1 ","State House","15","DEM ","McCormack, Patrick M ",178
 "15","15-310 Muldoon No. 1 ","State House","15","NP ","Write-in 30 ",2
-"15","15-310 Muldoon No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",351
-"15","15-310 Muldoon No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",187
+"15","15-310 Muldoon No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",351
+"15","15-310 Muldoon No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",187
 "15","15-310 Muldoon No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",202
 "15","15-310 Muldoon No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",321
 "15","15-310 Muldoon No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",237
@@ -7965,8 +7965,8 @@
 "15","15-315 Muldoon No. 2 ","State House","15","REP ","LeDoux, Gabrielle ",322
 "15","15-315 Muldoon No. 2 ","State House","15","DEM ","McCormack, Patrick M ",146
 "15","15-315 Muldoon No. 2 ","State House","15","NP ","Write-in 30 ",1
-"15","15-315 Muldoon No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",311
-"15","15-315 Muldoon No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",164
+"15","15-315 Muldoon No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",311
+"15","15-315 Muldoon No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",164
 "15","15-315 Muldoon No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",207
 "15","15-315 Muldoon No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",253
 "15","15-315 Muldoon No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",227
@@ -8036,8 +8036,8 @@
 "15","15-320 North Muldoon ","State House","15","REP ","LeDoux, Gabrielle ",338
 "15","15-320 North Muldoon ","State House","15","DEM ","McCormack, Patrick M ",159
 "15","15-320 North Muldoon ","State House","15","NP ","Write-in 30 ",2
-"15","15-320 North Muldoon ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",333
-"15","15-320 North Muldoon ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",174
+"15","15-320 North Muldoon ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",333
+"15","15-320 North Muldoon ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",174
 "15","15-320 North Muldoon ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",197
 "15","15-320 North Muldoon ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",293
 "15","15-320 North Muldoon ","Supreme Crt-Justice Bolger ","","NP ","YES ",265
@@ -8108,8 +8108,8 @@
 "16","16-325 Russian Jack ","State House","16","NA ","Sharrock, Ian ",34
 "16","16-325 Russian Jack ","State House","16","DEM ","Spohnholz, Ivy ",254
 "16","16-325 Russian Jack ","State House","16","NP ","Write-in 40 ",1
-"16","16-325 Russian Jack ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",326
-"16","16-325 Russian Jack ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",139
+"16","16-325 Russian Jack ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",326
+"16","16-325 Russian Jack ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",139
 "16","16-325 Russian Jack ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",213
 "16","16-325 Russian Jack ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",242
 "16","16-325 Russian Jack ","Supreme Crt-Justice Bolger ","","NP ","YES ",244
@@ -8180,8 +8180,8 @@
 "16","16-330 Nunaka Valley ","State House","16","NA ","Sharrock, Ian ",62
 "16","16-330 Nunaka Valley ","State House","16","DEM ","Spohnholz, Ivy ",362
 "16","16-330 Nunaka Valley ","State House","16","NP ","Write-in 40 ",2
-"16","16-330 Nunaka Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",497
-"16","16-330 Nunaka Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",255
+"16","16-330 Nunaka Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",497
+"16","16-330 Nunaka Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",255
 "16","16-330 Nunaka Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",323
 "16","16-330 Nunaka Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",404
 "16","16-330 Nunaka Valley ","Supreme Crt-Justice Bolger ","","NP ","YES ",351
@@ -8252,8 +8252,8 @@
 "16","16-335 Northeast Anchorage ","State House","16","NA ","Sharrock, Ian ",45
 "16","16-335 Northeast Anchorage ","State House","16","DEM ","Spohnholz, Ivy ",243
 "16","16-335 Northeast Anchorage ","State House","16","NP ","Write-in 40 ",0
-"16","16-335 Northeast Anchorage ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",360
-"16","16-335 Northeast Anchorage ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",188
+"16","16-335 Northeast Anchorage ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",360
+"16","16-335 Northeast Anchorage ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",188
 "16","16-335 Northeast Anchorage ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",225
 "16","16-335 Northeast Anchorage ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",304
 "16","16-335 Northeast Anchorage ","Supreme Crt-Justice Bolger ","","NP ","YES ",269
@@ -8324,8 +8324,8 @@
 "16","16-340 College Gate ","State House","16","NA ","Sharrock, Ian ",34
 "16","16-340 College Gate ","State House","16","DEM ","Spohnholz, Ivy ",333
 "16","16-340 College Gate ","State House","16","NP ","Write-in 40 ",0
-"16","16-340 College Gate ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",412
-"16","16-340 College Gate ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",227
+"16","16-340 College Gate ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",412
+"16","16-340 College Gate ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",227
 "16","16-340 College Gate ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",319
 "16","16-340 College Gate ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",309
 "16","16-340 College Gate ","Supreme Crt-Justice Bolger ","","NP ","YES ",353
@@ -8396,8 +8396,8 @@
 "16","16-345 Chester Valley ","State House","16","NA ","Sharrock, Ian ",33
 "16","16-345 Chester Valley ","State House","16","DEM ","Spohnholz, Ivy ",249
 "16","16-345 Chester Valley ","State House","16","NP ","Write-in 40 ",2
-"16","16-345 Chester Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",370
-"16","16-345 Chester Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",181
+"16","16-345 Chester Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",370
+"16","16-345 Chester Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",181
 "16","16-345 Chester Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",240
 "16","16-345 Chester Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",286
 "16","16-345 Chester Valley ","Supreme Crt-Justice Bolger ","","NP ","YES ",285
@@ -8468,8 +8468,8 @@
 "16","16-350 Reflection Lake ","State House","16","NA ","Sharrock, Ian ",57
 "16","16-350 Reflection Lake ","State House","16","DEM ","Spohnholz, Ivy ",490
 "16","16-350 Reflection Lake ","State House","16","NP ","Write-in 40 ",2
-"16","16-350 Reflection Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",670
-"16","16-350 Reflection Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",384
+"16","16-350 Reflection Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",670
+"16","16-350 Reflection Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",384
 "16","16-350 Reflection Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",431
 "16","16-350 Reflection Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",597
 "16","16-350 Reflection Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",527
@@ -8540,8 +8540,8 @@
 "16","16-355 Wonder Park ","State House","16","NA ","Sharrock, Ian ",53
 "16","16-355 Wonder Park ","State House","16","DEM ","Spohnholz, Ivy ",327
 "16","16-355 Wonder Park ","State House","16","NP ","Write-in 40 ",4
-"16","16-355 Wonder Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",421
-"16","16-355 Wonder Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",234
+"16","16-355 Wonder Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",421
+"16","16-355 Wonder Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",234
 "16","16-355 Wonder Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",298
 "16","16-355 Wonder Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",341
 "16","16-355 Wonder Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",314
@@ -8607,8 +8607,8 @@
 "17","17-400 Rogers Park ","U.S. House","1","NP ","Write-in 50 ",2
 "17","17-400 Rogers Park ","State House","17","DEM ","Josephson, Andrew L. ",420
 "17","17-400 Rogers Park ","State House","17","NP ","Write-in 20 ",55
-"17","17-400 Rogers Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",390
-"17","17-400 Rogers Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",228
+"17","17-400 Rogers Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",390
+"17","17-400 Rogers Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",228
 "17","17-400 Rogers Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",310
 "17","17-400 Rogers Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",297
 "17","17-400 Rogers Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",367
@@ -8674,8 +8674,8 @@
 "17","17-405 University No. 1 ","U.S. House","1","NP ","Write-in 50 ",0
 "17","17-405 University No. 1 ","State House","17","DEM ","Josephson, Andrew L. ",250
 "17","17-405 University No. 1 ","State House","17","NP ","Write-in 20 ",11
-"17","17-405 University No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",245
-"17","17-405 University No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",98
+"17","17-405 University No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",245
+"17","17-405 University No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",98
 "17","17-405 University No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",166
 "17","17-405 University No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",164
 "17","17-405 University No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",186
@@ -8741,8 +8741,8 @@
 "17","17-410 University No. 2 ","U.S. House","1","NP ","Write-in 50 ",1
 "17","17-410 University No. 2 ","State House","17","DEM ","Josephson, Andrew L. ",369
 "17","17-410 University No. 2 ","State House","17","NP ","Write-in 20 ",21
-"17","17-410 University No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",346
-"17","17-410 University No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",162
+"17","17-410 University No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",346
+"17","17-410 University No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",162
 "17","17-410 University No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",245
 "17","17-410 University No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",242
 "17","17-410 University No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",282
@@ -8808,8 +8808,8 @@
 "17","17-415 Far North Bicentennial ","U.S. House","1","NP ","Write-in 50 ",3
 "17","17-415 Far North Bicentennial ","State House","17","DEM ","Josephson, Andrew L. ",325
 "17","17-415 Far North Bicentennial ","State House","17","NP ","Write-in 20 ",30
-"17","17-415 Far North Bicentennial ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",321
-"17","17-415 Far North Bicentennial ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",156
+"17","17-415 Far North Bicentennial ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",321
+"17","17-415 Far North Bicentennial ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",156
 "17","17-415 Far North Bicentennial ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",207
 "17","17-415 Far North Bicentennial ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",248
 "17","17-415 Far North Bicentennial ","Supreme Crt-Justice Bolger ","","NP ","YES ",240
@@ -8875,8 +8875,8 @@
 "17","17-420 Tudor No. 1 ","U.S. House","1","NP ","Write-in 50 ",4
 "17","17-420 Tudor No. 1 ","State House","17","DEM ","Josephson, Andrew L. ",793
 "17","17-420 Tudor No. 1 ","State House","17","NP ","Write-in 20 ",53
-"17","17-420 Tudor No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",723
-"17","17-420 Tudor No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",364
+"17","17-420 Tudor No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",723
+"17","17-420 Tudor No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",364
 "17","17-420 Tudor No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",472
 "17","17-420 Tudor No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",576
 "17","17-420 Tudor No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",586
@@ -8942,8 +8942,8 @@
 "17","17-425 Tudor No. 2 ","U.S. House","1","NP ","Write-in 50 ",3
 "17","17-425 Tudor No. 2 ","State House","17","DEM ","Josephson, Andrew L. ",420
 "17","17-425 Tudor No. 2 ","State House","17","NP ","Write-in 20 ",36
-"17","17-425 Tudor No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",394
-"17","17-425 Tudor No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",183
+"17","17-425 Tudor No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",394
+"17","17-425 Tudor No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",183
 "17","17-425 Tudor No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",286
 "17","17-425 Tudor No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",274
 "17","17-425 Tudor No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",296
@@ -9009,8 +9009,8 @@
 "17","17-430 East Anchorage ","U.S. House","1","NP ","Write-in 50 ",1
 "17","17-430 East Anchorage ","State House","17","DEM ","Josephson, Andrew L. ",288
 "17","17-430 East Anchorage ","State House","17","NP ","Write-in 20 ",16
-"17","17-430 East Anchorage ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",260
-"17","17-430 East Anchorage ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",121
+"17","17-430 East Anchorage ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",260
+"17","17-430 East Anchorage ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",121
 "17","17-430 East Anchorage ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",180
 "17","17-430 East Anchorage ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",192
 "17","17-430 East Anchorage ","Supreme Crt-Justice Bolger ","","NP ","YES ",195
@@ -9077,8 +9077,8 @@
 "18","18-435 West Anchorage No. 1 ","State House","18","DEM ","Drummond, Harriet A. ",195
 "18","18-435 West Anchorage No. 1 ","State House","18","REP ","Gordon, Michael W.  ",186
 "18","18-435 West Anchorage No. 1 ","State House","18","NP ","Write-in 30 ",0
-"18","18-435 West Anchorage No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",261
-"18","18-435 West Anchorage No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",128
+"18","18-435 West Anchorage No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",261
+"18","18-435 West Anchorage No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",128
 "18","18-435 West Anchorage No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",222
 "18","18-435 West Anchorage No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",148
 "18","18-435 West Anchorage No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",242
@@ -9145,8 +9145,8 @@
 "18","18-440 West Anchorage No. 2 ","State House","18","DEM ","Drummond, Harriet A. ",148
 "18","18-440 West Anchorage No. 2 ","State House","18","REP ","Gordon, Michael W.  ",149
 "18","18-440 West Anchorage No. 2 ","State House","18","NP ","Write-in 30 ",3
-"18","18-440 West Anchorage No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",186
-"18","18-440 West Anchorage No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",121
+"18","18-440 West Anchorage No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",186
+"18","18-440 West Anchorage No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",121
 "18","18-440 West Anchorage No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",137
 "18","18-440 West Anchorage No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",164
 "18","18-440 West Anchorage No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",169
@@ -9213,8 +9213,8 @@
 "18","18-445 Spenard ","State House","18","DEM ","Drummond, Harriet A. ",239
 "18","18-445 Spenard ","State House","18","REP ","Gordon, Michael W.  ",219
 "18","18-445 Spenard ","State House","18","NP ","Write-in 30 ",2
-"18","18-445 Spenard ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",300
-"18","18-445 Spenard ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",168
+"18","18-445 Spenard ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",300
+"18","18-445 Spenard ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",168
 "18","18-445 Spenard ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",221
 "18","18-445 Spenard ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",228
 "18","18-445 Spenard ","Supreme Crt-Justice Bolger ","","NP ","YES ",223
@@ -9281,8 +9281,8 @@
 "18","18-450 Willow Crest ","State House","18","DEM ","Drummond, Harriet A. ",195
 "18","18-450 Willow Crest ","State House","18","REP ","Gordon, Michael W.  ",224
 "18","18-450 Willow Crest ","State House","18","NP ","Write-in 30 ",1
-"18","18-450 Willow Crest ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",272
-"18","18-450 Willow Crest ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",152
+"18","18-450 Willow Crest ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",272
+"18","18-450 Willow Crest ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",152
 "18","18-450 Willow Crest ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",201
 "18","18-450 Willow Crest ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",209
 "18","18-450 Willow Crest ","Supreme Crt-Justice Bolger ","","NP ","YES ",236
@@ -9349,8 +9349,8 @@
 "18","18-455 West Anchorage No. 3 ","State House","18","DEM ","Drummond, Harriet A. ",245
 "18","18-455 West Anchorage No. 3 ","State House","18","REP ","Gordon, Michael W.  ",196
 "18","18-455 West Anchorage No. 3 ","State House","18","NP ","Write-in 30 ",5
-"18","18-455 West Anchorage No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",312
-"18","18-455 West Anchorage No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",144
+"18","18-455 West Anchorage No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",312
+"18","18-455 West Anchorage No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",144
 "18","18-455 West Anchorage No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",225
 "18","18-455 West Anchorage No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",215
 "18","18-455 West Anchorage No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",240
@@ -9417,8 +9417,8 @@
 "18","18-460 Fireweed No. 1 ","State House","18","DEM ","Drummond, Harriet A. ",343
 "18","18-460 Fireweed No. 1 ","State House","18","REP ","Gordon, Michael W.  ",245
 "18","18-460 Fireweed No. 1 ","State House","18","NP ","Write-in 30 ",4
-"18","18-460 Fireweed No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",422
-"18","18-460 Fireweed No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",171
+"18","18-460 Fireweed No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",422
+"18","18-460 Fireweed No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",171
 "18","18-460 Fireweed No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",304
 "18","18-460 Fireweed No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",265
 "18","18-460 Fireweed No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",322
@@ -9485,8 +9485,8 @@
 "18","18-465 Fireweed No. 2 ","State House","18","DEM ","Drummond, Harriet A. ",152
 "18","18-465 Fireweed No. 2 ","State House","18","REP ","Gordon, Michael W.  ",115
 "18","18-465 Fireweed No. 2 ","State House","18","NP ","Write-in 30 ",1
-"18","18-465 Fireweed No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",192
-"18","18-465 Fireweed No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",78
+"18","18-465 Fireweed No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",192
+"18","18-465 Fireweed No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",78
 "18","18-465 Fireweed No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",127
 "18","18-465 Fireweed No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",134
 "18","18-465 Fireweed No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",152
@@ -9553,8 +9553,8 @@
 "18","18-470 Fireweed No. 3 ","State House","18","DEM ","Drummond, Harriet A. ",98
 "18","18-470 Fireweed No. 3 ","State House","18","REP ","Gordon, Michael W.  ",92
 "18","18-470 Fireweed No. 3 ","State House","18","NP ","Write-in 30 ",0
-"18","18-470 Fireweed No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",118
-"18","18-470 Fireweed No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",71
+"18","18-470 Fireweed No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",118
+"18","18-470 Fireweed No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",71
 "18","18-470 Fireweed No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",87
 "18","18-470 Fireweed No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",102
 "18","18-470 Fireweed No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",94
@@ -9621,8 +9621,8 @@
 "18","18-475 Midtown No. 1 ","State House","18","DEM ","Drummond, Harriet A. ",135
 "18","18-475 Midtown No. 1 ","State House","18","REP ","Gordon, Michael W.  ",142
 "18","18-475 Midtown No. 1 ","State House","18","NP ","Write-in 30 ",2
-"18","18-475 Midtown No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",175
-"18","18-475 Midtown No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",114
+"18","18-475 Midtown No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",175
+"18","18-475 Midtown No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",114
 "18","18-475 Midtown No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",126
 "18","18-475 Midtown No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",152
 "18","18-475 Midtown No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",167
@@ -9689,8 +9689,8 @@
 "18","18-480 Midtown No. 2 ","State House","18","DEM ","Drummond, Harriet A. ",396
 "18","18-480 Midtown No. 2 ","State House","18","REP ","Gordon, Michael W.  ",274
 "18","18-480 Midtown No. 2 ","State House","18","NP ","Write-in 30 ",5
-"18","18-480 Midtown No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",445
-"18","18-480 Midtown No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",234
+"18","18-480 Midtown No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",445
+"18","18-480 Midtown No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",234
 "18","18-480 Midtown No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",366
 "18","18-480 Midtown No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",288
 "18","18-480 Midtown No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",441
@@ -9758,8 +9758,8 @@
 "19","19-500 North Mt View No. 1 ","State Senate","J","NP ","Write-in 20 ",16
 "19","19-500 North Mt View No. 1 ","State House","19","DEM ","Tarr, Geran ",336
 "19","19-500 North Mt View No. 1 ","State House","19","NP ","Write-in 20 ",17
-"19","19-500 North Mt View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",295
-"19","19-500 North Mt View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",148
+"19","19-500 North Mt View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",295
+"19","19-500 North Mt View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",148
 "19","19-500 North Mt View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",201
 "19","19-500 North Mt View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",226
 "19","19-500 North Mt View No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",229
@@ -9827,8 +9827,8 @@
 "19","19-505 North Mt View No. 2 ","State Senate","J","NP ","Write-in 20 ",28
 "19","19-505 North Mt View No. 2 ","State House","19","DEM ","Tarr, Geran ",334
 "19","19-505 North Mt View No. 2 ","State House","19","NP ","Write-in 20 ",24
-"19","19-505 North Mt View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",312
-"19","19-505 North Mt View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",131
+"19","19-505 North Mt View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",312
+"19","19-505 North Mt View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",131
 "19","19-505 North Mt View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",210
 "19","19-505 North Mt View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",221
 "19","19-505 North Mt View No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",221
@@ -9896,8 +9896,8 @@
 "19","19-510 South Mt View No. 1 ","State Senate","J","NP ","Write-in 20 ",33
 "19","19-510 South Mt View No. 1 ","State House","19","DEM ","Tarr, Geran ",433
 "19","19-510 South Mt View No. 1 ","State House","19","NP ","Write-in 20 ",34
-"19","19-510 South Mt View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",388
-"19","19-510 South Mt View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",206
+"19","19-510 South Mt View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",388
+"19","19-510 South Mt View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",206
 "19","19-510 South Mt View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",274
 "19","19-510 South Mt View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",307
 "19","19-510 South Mt View No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",299
@@ -9965,8 +9965,8 @@
 "19","19-515 South Mt View No. 2 ","State Senate","J","NP ","Write-in 20 ",7
 "19","19-515 South Mt View No. 2 ","State House","19","DEM ","Tarr, Geran ",182
 "19","19-515 South Mt View No. 2 ","State House","19","NP ","Write-in 20 ",8
-"19","19-515 South Mt View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",168
-"19","19-515 South Mt View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",83
+"19","19-515 South Mt View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",168
+"19","19-515 South Mt View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",83
 "19","19-515 South Mt View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",108
 "19","19-515 South Mt View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",141
 "19","19-515 South Mt View No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",127
@@ -10034,8 +10034,8 @@
 "19","19-520 Airport Heights No. 1 ","State Senate","J","NP ","Write-in 20 ",28
 "19","19-520 Airport Heights No. 1 ","State House","19","DEM ","Tarr, Geran ",418
 "19","19-520 Airport Heights No. 1 ","State House","19","NP ","Write-in 20 ",31
-"19","19-520 Airport Heights No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",372
-"19","19-520 Airport Heights No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",189
+"19","19-520 Airport Heights No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",372
+"19","19-520 Airport Heights No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",189
 "19","19-520 Airport Heights No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",270
 "19","19-520 Airport Heights No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",279
 "19","19-520 Airport Heights No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",298
@@ -10103,8 +10103,8 @@
 "19","19-525 Airport Heights No. 2 ","State Senate","J","NP ","Write-in 20 ",33
 "19","19-525 Airport Heights No. 2 ","State House","19","DEM ","Tarr, Geran ",664
 "19","19-525 Airport Heights No. 2 ","State House","19","NP ","Write-in 20 ",32
-"19","19-525 Airport Heights No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",581
-"19","19-525 Airport Heights No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",265
+"19","19-525 Airport Heights No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",581
+"19","19-525 Airport Heights No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",265
 "19","19-525 Airport Heights No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",482
 "19","19-525 Airport Heights No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",335
 "19","19-525 Airport Heights No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",515
@@ -10172,8 +10172,8 @@
 "20","20-530 Government Hill ","State Senate","J","NP ","Write-in 20 ",23
 "20","20-530 Government Hill ","State House","20","DEM ","Gara, Les S.  ",353
 "20","20-530 Government Hill ","State House","20","NP ","Write-in 20 ",23
-"20","20-530 Government Hill ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",314
-"20","20-530 Government Hill ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",148
+"20","20-530 Government Hill ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",314
+"20","20-530 Government Hill ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",148
 "20","20-530 Government Hill ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",226
 "20","20-530 Government Hill ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",224
 "20","20-530 Government Hill ","Supreme Crt-Justice Bolger ","","NP ","YES ",250
@@ -10241,8 +10241,8 @@
 "20","20-535 Merrill Field ","State Senate","J","NP ","Write-in 20 ",34
 "20","20-535 Merrill Field ","State House","20","DEM ","Gara, Les S.  ",564
 "20","20-535 Merrill Field ","State House","20","NP ","Write-in 20 ",39
-"20","20-535 Merrill Field ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",511
-"20","20-535 Merrill Field ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",238
+"20","20-535 Merrill Field ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",511
+"20","20-535 Merrill Field ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",238
 "20","20-535 Merrill Field ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",397
 "20","20-535 Merrill Field ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",318
 "20","20-535 Merrill Field ","Supreme Crt-Justice Bolger ","","NP ","YES ",414
@@ -10310,8 +10310,8 @@
 "20","20-540 Downtown Anch No. 1 ","State Senate","J","NP ","Write-in 20 ",20
 "20","20-540 Downtown Anch No. 1 ","State House","20","DEM ","Gara, Les S.  ",165
 "20","20-540 Downtown Anch No. 1 ","State House","20","NP ","Write-in 20 ",19
-"20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",163
-"20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",84
+"20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",163
+"20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",84
 "20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "20","20-540 Downtown Anch No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",118
 "20","20-540 Downtown Anch No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",147
@@ -10379,8 +10379,8 @@
 "20","20-545 Downtown Anch No. 2 ","State Senate","J","NP ","Write-in 20 ",16
 "20","20-545 Downtown Anch No. 2 ","State House","20","DEM ","Gara, Les S.  ",280
 "20","20-545 Downtown Anch No. 2 ","State House","20","NP ","Write-in 20 ",16
-"20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",248
-"20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",123
+"20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",248
+"20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",123
 "20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",211
 "20","20-545 Downtown Anch No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",145
 "20","20-545 Downtown Anch No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",226
@@ -10448,8 +10448,8 @@
 "20","20-550 Downtown Anch No. 3 ","State Senate","J","NP ","Write-in 20 ",12
 "20","20-550 Downtown Anch No. 3 ","State House","20","DEM ","Gara, Les S.  ",130
 "20","20-550 Downtown Anch No. 3 ","State House","20","NP ","Write-in 20 ",10
-"20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",119
-"20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",61
+"20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",119
+"20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",61
 "20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",100
 "20","20-550 Downtown Anch No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",69
 "20","20-550 Downtown Anch No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",100
@@ -10517,8 +10517,8 @@
 "20","20-555 Downtown Anch No. 4 ","State Senate","J","NP ","Write-in 20 ",23
 "20","20-555 Downtown Anch No. 4 ","State House","20","DEM ","Gara, Les S.  ",389
 "20","20-555 Downtown Anch No. 4 ","State House","20","NP ","Write-in 20 ",22
-"20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",360
-"20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",167
+"20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",360
+"20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",167
 "20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",246
 "20","20-555 Downtown Anch No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",256
 "20","20-555 Downtown Anch No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",278
@@ -10586,8 +10586,8 @@
 "20","20-560 Inlet View ","State Senate","J","NP ","Write-in 20 ",34
 "20","20-560 Inlet View ","State House","20","DEM ","Gara, Les S.  ",346
 "20","20-560 Inlet View ","State House","20","NP ","Write-in 20 ",42
-"20","20-560 Inlet View ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",339
-"20","20-560 Inlet View ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",140
+"20","20-560 Inlet View ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",339
+"20","20-560 Inlet View ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",140
 "20","20-560 Inlet View ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",268
 "20","20-560 Inlet View ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",192
 "20","20-560 Inlet View ","Supreme Crt-Justice Bolger ","","NP ","YES ",294
@@ -10655,8 +10655,8 @@
 "20","20-565 Westchester ","State Senate","J","NP ","Write-in 20 ",13
 "20","20-565 Westchester ","State House","20","DEM ","Gara, Les S.  ",250
 "20","20-565 Westchester ","State House","20","NP ","Write-in 20 ",16
-"20","20-565 Westchester ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",250
-"20","20-565 Westchester ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",92
+"20","20-565 Westchester ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",250
+"20","20-565 Westchester ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",92
 "20","20-565 Westchester ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",192
 "20","20-565 Westchester ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",133
 "20","20-565 Westchester ","Supreme Crt-Justice Bolger ","","NP ","YES ",219
@@ -10724,8 +10724,8 @@
 "20","20-570 Fairview ","State Senate","J","NP ","Write-in 20 ",30
 "20","20-570 Fairview ","State House","20","DEM ","Gara, Les S.  ",342
 "20","20-570 Fairview ","State House","20","NP ","Write-in 20 ",27
-"20","20-570 Fairview ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",302
-"20","20-570 Fairview ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",158
+"20","20-570 Fairview ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",302
+"20","20-570 Fairview ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",158
 "20","20-570 Fairview ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",216
 "20","20-570 Fairview ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",227
 "20","20-570 Fairview ","Supreme Crt-Justice Bolger ","","NP ","YES ",236
@@ -10792,8 +10792,8 @@
 "21","21-600 Turnagain No. 1 ","State House","21","REP ","Stewart, Marilyn ",343
 "21","21-600 Turnagain No. 1 ","State House","21","DEM ","Claman, Matt ",521
 "21","21-600 Turnagain No. 1 ","State House","21","NP ","Write-in 30 ",1
-"21","21-600 Turnagain No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",567
-"21","21-600 Turnagain No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",298
+"21","21-600 Turnagain No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",567
+"21","21-600 Turnagain No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",298
 "21","21-600 Turnagain No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",492
 "21","21-600 Turnagain No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",346
 "21","21-600 Turnagain No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",552
@@ -10860,8 +10860,8 @@
 "21","21-605 Sand Lake No. 1 ","State House","21","REP ","Stewart, Marilyn ",431
 "21","21-605 Sand Lake No. 1 ","State House","21","DEM ","Claman, Matt ",344
 "21","21-605 Sand Lake No. 1 ","State House","21","NP ","Write-in 30 ",7
-"21","21-605 Sand Lake No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",470
-"21","21-605 Sand Lake No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",319
+"21","21-605 Sand Lake No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",470
+"21","21-605 Sand Lake No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",319
 "21","21-605 Sand Lake No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",323
 "21","21-605 Sand Lake No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",450
 "21","21-605 Sand Lake No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",393
@@ -10928,8 +10928,8 @@
 "21","21-610 Sand Lake No. 2 ","State House","21","REP ","Stewart, Marilyn ",384
 "21","21-610 Sand Lake No. 2 ","State House","21","DEM ","Claman, Matt ",281
 "21","21-610 Sand Lake No. 2 ","State House","21","NP ","Write-in 30 ",1
-"21","21-610 Sand Lake No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",429
-"21","21-610 Sand Lake No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",252
+"21","21-610 Sand Lake No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",429
+"21","21-610 Sand Lake No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",252
 "21","21-610 Sand Lake No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",283
 "21","21-610 Sand Lake No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",376
 "21","21-610 Sand Lake No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",369
@@ -10996,8 +10996,8 @@
 "21","21-615 Sand Lake No. 3 ","State House","21","REP ","Stewart, Marilyn ",300
 "21","21-615 Sand Lake No. 3 ","State House","21","DEM ","Claman, Matt ",254
 "21","21-615 Sand Lake No. 3 ","State House","21","NP ","Write-in 30 ",3
-"21","21-615 Sand Lake No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",360
-"21","21-615 Sand Lake No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",212
+"21","21-615 Sand Lake No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",360
+"21","21-615 Sand Lake No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",212
 "21","21-615 Sand Lake No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",249
 "21","21-615 Sand Lake No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",303
 "21","21-615 Sand Lake No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",301
@@ -11064,8 +11064,8 @@
 "21","21-620 Lake Spenard ","State House","21","REP ","Stewart, Marilyn ",304
 "21","21-620 Lake Spenard ","State House","21","DEM ","Claman, Matt ",250
 "21","21-620 Lake Spenard ","State House","21","NP ","Write-in 30 ",0
-"21","21-620 Lake Spenard ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",373
-"21","21-620 Lake Spenard ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",198
+"21","21-620 Lake Spenard ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",373
+"21","21-620 Lake Spenard ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",198
 "21","21-620 Lake Spenard ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",227
 "21","21-620 Lake Spenard ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",324
 "21","21-620 Lake Spenard ","Supreme Crt-Justice Bolger ","","NP ","YES ",302
@@ -11132,8 +11132,8 @@
 "21","21-625 Lake Hood ","State House","21","REP ","Stewart, Marilyn ",368
 "21","21-625 Lake Hood ","State House","21","DEM ","Claman, Matt ",413
 "21","21-625 Lake Hood ","State House","21","NP ","Write-in 30 ",8
-"21","21-625 Lake Hood ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",501
-"21","21-625 Lake Hood ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",287
+"21","21-625 Lake Hood ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",501
+"21","21-625 Lake Hood ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",287
 "21","21-625 Lake Hood ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",370
 "21","21-625 Lake Hood ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",398
 "21","21-625 Lake Hood ","Supreme Crt-Justice Bolger ","","NP ","YES ",432
@@ -11200,8 +11200,8 @@
 "21","21-630 Turnagain No. 2 ","State House","21","REP ","Stewart, Marilyn ",195
 "21","21-630 Turnagain No. 2 ","State House","21","DEM ","Claman, Matt ",235
 "21","21-630 Turnagain No. 2 ","State House","21","NP ","Write-in 30 ",4
-"21","21-630 Turnagain No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",290
-"21","21-630 Turnagain No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",154
+"21","21-630 Turnagain No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",290
+"21","21-630 Turnagain No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",154
 "21","21-630 Turnagain No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",197
 "21","21-630 Turnagain No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",233
 "21","21-630 Turnagain No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",233
@@ -11268,8 +11268,8 @@
 "21","21-635 Turnagain No. 3 ","State House","21","REP ","Stewart, Marilyn ",370
 "21","21-635 Turnagain No. 3 ","State House","21","DEM ","Claman, Matt ",397
 "21","21-635 Turnagain No. 3 ","State House","21","NP ","Write-in 30 ",3
-"21","21-635 Turnagain No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",539
-"21","21-635 Turnagain No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",236
+"21","21-635 Turnagain No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",539
+"21","21-635 Turnagain No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",236
 "21","21-635 Turnagain No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",374
 "21","21-635 Turnagain No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",367
 "21","21-635 Turnagain No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",454
@@ -11337,8 +11337,8 @@
 "22","22-640 Dimond No. 1 ","State House","22","REP ","Vazquez, Liz ",435
 "22","22-640 Dimond No. 1 ","State House","22","NA ","Grenn, Jason S.  ",351
 "22","22-640 Dimond No. 1 ","State House","22","NP ","Write-in 40 ",2
-"22","22-640 Dimond No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",569
-"22","22-640 Dimond No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",350
+"22","22-640 Dimond No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",569
+"22","22-640 Dimond No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",350
 "22","22-640 Dimond No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",382
 "22","22-640 Dimond No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",506
 "22","22-640 Dimond No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",453
@@ -11406,8 +11406,8 @@
 "22","22-645 Kincaid ","State House","22","REP ","Vazquez, Liz ",578
 "22","22-645 Kincaid ","State House","22","NA ","Grenn, Jason S.  ",668
 "22","22-645 Kincaid ","State House","22","NP ","Write-in 40 ",1
-"22","22-645 Kincaid ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",796
-"22","22-645 Kincaid ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",553
+"22","22-645 Kincaid ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",796
+"22","22-645 Kincaid ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",553
 "22","22-645 Kincaid ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",561
 "22","22-645 Kincaid ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",745
 "22","22-645 Kincaid ","Supreme Crt-Justice Bolger ","","NP ","YES ",745
@@ -11475,8 +11475,8 @@
 "22","22-650 Jewel Lake No. 1 ","State House","22","REP ","Vazquez, Liz ",263
 "22","22-650 Jewel Lake No. 1 ","State House","22","NA ","Grenn, Jason S.  ",253
 "22","22-650 Jewel Lake No. 1 ","State House","22","NP ","Write-in 40 ",2
-"22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",381
-"22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",208
+"22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",381
+"22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",208
 "22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",252
 "22","22-650 Jewel Lake No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",317
 "22","22-650 Jewel Lake No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",328
@@ -11544,8 +11544,8 @@
 "22","22-655 Jewel Lake No. 2 ","State House","22","REP ","Vazquez, Liz ",295
 "22","22-655 Jewel Lake No. 2 ","State House","22","NA ","Grenn, Jason S.  ",252
 "22","22-655 Jewel Lake No. 2 ","State House","22","NP ","Write-in 40 ",0
-"22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",387
-"22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",241
+"22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",387
+"22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",241
 "22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",274
 "22","22-655 Jewel Lake No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",336
 "22","22-655 Jewel Lake No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",291
@@ -11613,8 +11613,8 @@
 "22","22-660 Campbell Lake ","State House","22","REP ","Vazquez, Liz ",442
 "22","22-660 Campbell Lake ","State House","22","NA ","Grenn, Jason S.  ",491
 "22","22-660 Campbell Lake ","State House","22","NP ","Write-in 40 ",2
-"22","22-660 Campbell Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",650
-"22","22-660 Campbell Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",379
+"22","22-660 Campbell Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",650
+"22","22-660 Campbell Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",379
 "22","22-660 Campbell Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",461
 "22","22-660 Campbell Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",550
 "22","22-660 Campbell Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",547
@@ -11682,8 +11682,8 @@
 "22","22-665 Sand Lake No. 4 ","State House","22","REP ","Vazquez, Liz ",283
 "22","22-665 Sand Lake No. 4 ","State House","22","NA ","Grenn, Jason S.  ",349
 "22","22-665 Sand Lake No. 4 ","State House","22","NP ","Write-in 40 ",2
-"22","22-665 Sand Lake No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",435
-"22","22-665 Sand Lake No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",280
+"22","22-665 Sand Lake No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",435
+"22","22-665 Sand Lake No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",280
 "22","22-665 Sand Lake No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",305
 "22","22-665 Sand Lake No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",386
 "22","22-665 Sand Lake No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",368
@@ -11751,8 +11751,8 @@
 "22","22-670 Sand Lake No. 5 ","State House","22","REP ","Vazquez, Liz ",174
 "22","22-670 Sand Lake No. 5 ","State House","22","NA ","Grenn, Jason S.  ",181
 "22","22-670 Sand Lake No. 5 ","State House","22","NP ","Write-in 40 ",2
-"22","22-670 Sand Lake No. 5 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",221
-"22","22-670 Sand Lake No. 5 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",159
+"22","22-670 Sand Lake No. 5 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",221
+"22","22-670 Sand Lake No. 5 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",159
 "22","22-670 Sand Lake No. 5 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",148
 "22","22-670 Sand Lake No. 5 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",224
 "22","22-670 Sand Lake No. 5 ","Supreme Crt-Justice Bolger ","","NP ","YES ",216
@@ -11823,8 +11823,8 @@
 "23","23-735 Northwood ","State House","23","DEM ","Tuck, Chris S.  ",231
 "23","23-735 Northwood ","State House","23","REP ","Huit, Timothy R.  ",143
 "23","23-735 Northwood ","State House","23","NP ","Write-in 30 ",3
-"23","23-735 Northwood ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",250
-"23","23-735 Northwood ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",135
+"23","23-735 Northwood ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",250
+"23","23-735 Northwood ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",135
 "23","23-735 Northwood ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",174
 "23","23-735 Northwood ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",202
 "23","23-735 Northwood ","Supreme Crt-Justice Bolger ","","NP ","YES ",196
@@ -11895,8 +11895,8 @@
 "23","23-740 Arctic ","State House","23","DEM ","Tuck, Chris S.  ",359
 "23","23-740 Arctic ","State House","23","REP ","Huit, Timothy R.  ",299
 "23","23-740 Arctic ","State House","23","NP ","Write-in 30 ",1
-"23","23-740 Arctic ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",420
-"23","23-740 Arctic ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",253
+"23","23-740 Arctic ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",420
+"23","23-740 Arctic ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",253
 "23","23-740 Arctic ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",295
 "23","23-740 Arctic ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",358
 "23","23-740 Arctic ","Supreme Crt-Justice Bolger ","","NP ","YES ",315
@@ -11967,8 +11967,8 @@
 "23","23-745 Midtown No. 3 ","State House","23","DEM ","Tuck, Chris S.  ",184
 "23","23-745 Midtown No. 3 ","State House","23","REP ","Huit, Timothy R.  ",158
 "23","23-745 Midtown No. 3 ","State House","23","NP ","Write-in 30 ",3
-"23","23-745 Midtown No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",227
-"23","23-745 Midtown No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",123
+"23","23-745 Midtown No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",227
+"23","23-745 Midtown No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",123
 "23","23-745 Midtown No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",158
 "23","23-745 Midtown No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",186
 "23","23-745 Midtown No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",194
@@ -12039,8 +12039,8 @@
 "23","23-750 Taku ","State House","23","DEM ","Tuck, Chris S.  ",332
 "23","23-750 Taku ","State House","23","REP ","Huit, Timothy R.  ",340
 "23","23-750 Taku ","State House","23","NP ","Write-in 30 ",3
-"23","23-750 Taku ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",427
-"23","23-750 Taku ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",258
+"23","23-750 Taku ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",427
+"23","23-750 Taku ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",258
 "23","23-750 Taku ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",272
 "23","23-750 Taku ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",389
 "23","23-750 Taku ","Supreme Crt-Justice Bolger ","","NP ","YES ",309
@@ -12111,8 +12111,8 @@
 "23","23-755 Campbell Creek No. 1 ","State House","23","DEM ","Tuck, Chris S.  ",386
 "23","23-755 Campbell Creek No. 1 ","State House","23","REP ","Huit, Timothy R.  ",270
 "23","23-755 Campbell Creek No. 1 ","State House","23","NP ","Write-in 30 ",3
-"23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",393
-"23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",261
+"23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",393
+"23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",261
 "23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",262
 "23","23-755 Campbell Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",379
 "23","23-755 Campbell Creek No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",320
@@ -12183,8 +12183,8 @@
 "23","23-760 Campbell Creek No. 2 ","State House","23","DEM ","Tuck, Chris S.  ",237
 "23","23-760 Campbell Creek No. 2 ","State House","23","REP ","Huit, Timothy R.  ",193
 "23","23-760 Campbell Creek No. 2 ","State House","23","NP ","Write-in 30 ",0
-"23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",256
-"23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",170
+"23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",256
+"23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",170
 "23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",189
 "23","23-760 Campbell Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",235
 "23","23-760 Campbell Creek No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",225
@@ -12255,8 +12255,8 @@
 "23","23-765 Campbell Creek No. 3 ","State House","23","DEM ","Tuck, Chris S.  ",472
 "23","23-765 Campbell Creek No. 3 ","State House","23","REP ","Huit, Timothy R.  ",320
 "23","23-765 Campbell Creek No. 3 ","State House","23","NP ","Write-in 30 ",4
-"23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",511
-"23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",288
+"23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",511
+"23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",288
 "23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",353
 "23","23-765 Campbell Creek No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",429
 "23","23-765 Campbell Creek No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",415
@@ -12327,8 +12327,8 @@
 "23","23-770 Dimond No. 2 ","State House","23","DEM ","Tuck, Chris S.  ",310
 "23","23-770 Dimond No. 2 ","State House","23","REP ","Huit, Timothy R.  ",257
 "23","23-770 Dimond No. 2 ","State House","23","NP ","Write-in 30 ",5
-"23","23-770 Dimond No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",358
-"23","23-770 Dimond No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",219
+"23","23-770 Dimond No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",358
+"23","23-770 Dimond No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",219
 "23","23-770 Dimond No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",246
 "23","23-770 Dimond No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",321
 "23","23-770 Dimond No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",269
@@ -12399,8 +12399,8 @@
 "24","24-700 Huffman No. 1 ","State House","24","DEM ","Levi, Sue ",278
 "24","24-700 Huffman No. 1 ","State House","24","REP ","Kopp, Charles M.  ",460
 "24","24-700 Huffman No. 1 ","State House","24","NP ","Write-in 30 ",1
-"24","24-700 Huffman No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",399
-"24","24-700 Huffman No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",354
+"24","24-700 Huffman No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",399
+"24","24-700 Huffman No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",354
 "24","24-700 Huffman No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",288
 "24","24-700 Huffman No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",451
 "24","24-700 Huffman No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",380
@@ -12471,8 +12471,8 @@
 "24","24-705 Huffman No. 2 ","State House","24","DEM ","Levi, Sue ",253
 "24","24-705 Huffman No. 2 ","State House","24","REP ","Kopp, Charles M.  ",340
 "24","24-705 Huffman No. 2 ","State House","24","NP ","Write-in 30 ",7
-"24","24-705 Huffman No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",384
-"24","24-705 Huffman No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",241
+"24","24-705 Huffman No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",384
+"24","24-705 Huffman No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",241
 "24","24-705 Huffman No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",253
 "24","24-705 Huffman No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",357
 "24","24-705 Huffman No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",295
@@ -12543,8 +12543,8 @@
 "24","24-710 Klatt ","State House","24","DEM ","Levi, Sue ",330
 "24","24-710 Klatt ","State House","24","REP ","Kopp, Charles M.  ",576
 "24","24-710 Klatt ","State House","24","NP ","Write-in 30 ",4
-"24","24-710 Klatt ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",531
-"24","24-710 Klatt ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",395
+"24","24-710 Klatt ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",531
+"24","24-710 Klatt ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",395
 "24","24-710 Klatt ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",393
 "24","24-710 Klatt ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",510
 "24","24-710 Klatt ","Supreme Crt-Justice Bolger ","","NP ","YES ",490
@@ -12615,8 +12615,8 @@
 "24","24-715 Southport ","State House","24","DEM ","Levi, Sue ",307
 "24","24-715 Southport ","State House","24","REP ","Kopp, Charles M.  ",436
 "24","24-715 Southport ","State House","24","NP ","Write-in 30 ",1
-"24","24-715 Southport ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",477
-"24","24-715 Southport ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",285
+"24","24-715 Southport ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",477
+"24","24-715 Southport ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",285
 "24","24-715 Southport ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",342
 "24","24-715 Southport ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",400
 "24","24-715 Southport ","Supreme Crt-Justice Bolger ","","NP ","YES ",392
@@ -12687,8 +12687,8 @@
 "24","24-720 Ocean View No. 1 ","State House","24","DEM ","Levi, Sue ",283
 "24","24-720 Ocean View No. 1 ","State House","24","REP ","Kopp, Charles M.  ",436
 "24","24-720 Ocean View No. 1 ","State House","24","NP ","Write-in 30 ",2
-"24","24-720 Ocean View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",435
-"24","24-720 Ocean View No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",302
+"24","24-720 Ocean View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",435
+"24","24-720 Ocean View No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",302
 "24","24-720 Ocean View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",296
 "24","24-720 Ocean View No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",413
 "24","24-720 Ocean View No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",361
@@ -12759,8 +12759,8 @@
 "24","24-725 Ocean View No. 2 ","State House","24","DEM ","Levi, Sue ",390
 "24","24-725 Ocean View No. 2 ","State House","24","REP ","Kopp, Charles M.  ",544
 "24","24-725 Ocean View No. 2 ","State House","24","NP ","Write-in 30 ",3
-"24","24-725 Ocean View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",553
-"24","24-725 Ocean View No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",407
+"24","24-725 Ocean View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",553
+"24","24-725 Ocean View No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",407
 "24","24-725 Ocean View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",409
 "24","24-725 Ocean View No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",532
 "24","24-725 Ocean View No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",474
@@ -12831,8 +12831,8 @@
 "24","24-730 Bayshore ","State House","24","DEM ","Levi, Sue ",448
 "24","24-730 Bayshore ","State House","24","REP ","Kopp, Charles M.  ",704
 "24","24-730 Bayshore ","State House","24","NP ","Write-in 30 ",4
-"24","24-730 Bayshore ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",713
-"24","24-730 Bayshore ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",469
+"24","24-730 Bayshore ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",713
+"24","24-730 Bayshore ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",469
 "24","24-730 Bayshore ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",521
 "24","24-730 Bayshore ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",621
 "24","24-730 Bayshore ","Supreme Crt-Justice Bolger ","","NP ","YES ",596
@@ -12899,8 +12899,8 @@
 "25","25-840 East Dowling No. 1 ","State House","25","DEM ","Higgins, Pat ",110
 "25","25-840 East Dowling No. 1 ","State House","25","REP ","Millett, Charisse E. ",119
 "25","25-840 East Dowling No. 1 ","State House","25","NP ","Write-in 30 ",1
-"25","25-840 East Dowling No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",159
-"25","25-840 East Dowling No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",80
+"25","25-840 East Dowling No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",159
+"25","25-840 East Dowling No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",80
 "25","25-840 East Dowling No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",89
 "25","25-840 East Dowling No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",139
 "25","25-840 East Dowling No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",105
@@ -12967,8 +12967,8 @@
 "25","25-845 Elmore No. 1 ","State House","25","DEM ","Higgins, Pat ",548
 "25","25-845 Elmore No. 1 ","State House","25","REP ","Millett, Charisse E. ",569
 "25","25-845 Elmore No. 1 ","State House","25","NP ","Write-in 30 ",6
-"25","25-845 Elmore No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",715
-"25","25-845 Elmore No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",434
+"25","25-845 Elmore No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",715
+"25","25-845 Elmore No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",434
 "25","25-845 Elmore No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",504
 "25","25-845 Elmore No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",592
 "25","25-845 Elmore No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",574
@@ -13035,8 +13035,8 @@
 "25","25-850 Abbott No. 1 ","State House","25","DEM ","Higgins, Pat ",443
 "25","25-850 Abbott No. 1 ","State House","25","REP ","Millett, Charisse E. ",449
 "25","25-850 Abbott No. 1 ","State House","25","NP ","Write-in 30 ",0
-"25","25-850 Abbott No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",599
-"25","25-850 Abbott No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",305
+"25","25-850 Abbott No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",599
+"25","25-850 Abbott No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",305
 "25","25-850 Abbott No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",403
 "25","25-850 Abbott No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",473
 "25","25-850 Abbott No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",499
@@ -13103,8 +13103,8 @@
 "25","25-855 Lore No. 1 ","State House","25","DEM ","Higgins, Pat ",394
 "25","25-855 Lore No. 1 ","State House","25","REP ","Millett, Charisse E. ",469
 "25","25-855 Lore No. 1 ","State House","25","NP ","Write-in 30 ",5
-"25","25-855 Lore No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",512
-"25","25-855 Lore No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",374
+"25","25-855 Lore No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",512
+"25","25-855 Lore No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",374
 "25","25-855 Lore No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",357
 "25","25-855 Lore No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",508
 "25","25-855 Lore No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",418
@@ -13171,8 +13171,8 @@
 "25","25-860 Lore No. 2 ","State House","25","DEM ","Higgins, Pat ",337
 "25","25-860 Lore No. 2 ","State House","25","REP ","Millett, Charisse E. ",386
 "25","25-860 Lore No. 2 ","State House","25","NP ","Write-in 30 ",4
-"25","25-860 Lore No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",482
-"25","25-860 Lore No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",263
+"25","25-860 Lore No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",482
+"25","25-860 Lore No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",263
 "25","25-860 Lore No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",335
 "25","25-860 Lore No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",381
 "25","25-860 Lore No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",378
@@ -13239,8 +13239,8 @@
 "25","25-865 Abbott No. 2 ","State House","25","DEM ","Higgins, Pat ",282
 "25","25-865 Abbott No. 2 ","State House","25","REP ","Millett, Charisse E. ",318
 "25","25-865 Abbott No. 2 ","State House","25","NP ","Write-in 30 ",2
-"25","25-865 Abbott No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",388
-"25","25-865 Abbott No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",227
+"25","25-865 Abbott No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",388
+"25","25-865 Abbott No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",227
 "25","25-865 Abbott No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",263
 "25","25-865 Abbott No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",336
 "25","25-865 Abbott No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",308
@@ -13307,8 +13307,8 @@
 "25","25-870 East Dowling No. 2 ","State House","25","DEM ","Higgins, Pat ",457
 "25","25-870 East Dowling No. 2 ","State House","25","REP ","Millett, Charisse E. ",383
 "25","25-870 East Dowling No. 2 ","State House","25","NP ","Write-in 30 ",5
-"25","25-870 East Dowling No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",561
-"25","25-870 East Dowling No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",317
+"25","25-870 East Dowling No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",561
+"25","25-870 East Dowling No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",317
 "25","25-870 East Dowling No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",376
 "25","25-870 East Dowling No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",472
 "25","25-870 East Dowling No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",442
@@ -13375,8 +13375,8 @@
 "26","26-800 Independence Park No. 1 ","State House","26","REP ","Birch, Chris ",480
 "26","26-800 Independence Park No. 1 ","State House","26","DEM ","Gillespie, David M.  ",294
 "26","26-800 Independence Park No. 1 ","State House","26","NP ","Write-in 30 ",3
-"26","26-800 Independence Park No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",525
-"26","26-800 Independence Park No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",263
+"26","26-800 Independence Park No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",525
+"26","26-800 Independence Park No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",263
 "26","26-800 Independence Park No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",321
 "26","26-800 Independence Park No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",444
 "26","26-800 Independence Park No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",375
@@ -13443,8 +13443,8 @@
 "26","26-805 O'Malley No. 1 ","State House","26","REP ","Birch, Chris ",517
 "26","26-805 O'Malley No. 1 ","State House","26","DEM ","Gillespie, David M.  ",241
 "26","26-805 O'Malley No. 1 ","State House","26","NP ","Write-in 30 ",5
-"26","26-805 O'Malley No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",465
-"26","26-805 O'Malley No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",314
+"26","26-805 O'Malley No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",465
+"26","26-805 O'Malley No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",314
 "26","26-805 O'Malley No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",302
 "26","26-805 O'Malley No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",461
 "26","26-805 O'Malley No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",405
@@ -13511,8 +13511,8 @@
 "26","26-810 Huffman No. 3 ","State House","26","REP ","Birch, Chris ",462
 "26","26-810 Huffman No. 3 ","State House","26","DEM ","Gillespie, David M.  ",149
 "26","26-810 Huffman No. 3 ","State House","26","NP ","Write-in 30 ",1
-"26","26-810 Huffman No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",329
-"26","26-810 Huffman No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",295
+"26","26-810 Huffman No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",329
+"26","26-810 Huffman No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",295
 "26","26-810 Huffman No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",204
 "26","26-810 Huffman No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",393
 "26","26-810 Huffman No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",286
@@ -13579,8 +13579,8 @@
 "26","26-815 Huffman No. 4 ","State House","26","REP ","Birch, Chris ",635
 "26","26-815 Huffman No. 4 ","State House","26","DEM ","Gillespie, David M.  ",313
 "26","26-815 Huffman No. 4 ","State House","26","NP ","Write-in 30 ",3
-"26","26-815 Huffman No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",560
-"26","26-815 Huffman No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",402
+"26","26-815 Huffman No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",560
+"26","26-815 Huffman No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",402
 "26","26-815 Huffman No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",370
 "26","26-815 Huffman No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",570
 "26","26-815 Huffman No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",517
@@ -13647,8 +13647,8 @@
 "26","26-820 O'Malley No. 2 ","State House","26","REP ","Birch, Chris ",656
 "26","26-820 O'Malley No. 2 ","State House","26","DEM ","Gillespie, David M.  ",319
 "26","26-820 O'Malley No. 2 ","State House","26","NP ","Write-in 30 ",4
-"26","26-820 O'Malley No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",569
-"26","26-820 O'Malley No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",415
+"26","26-820 O'Malley No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",569
+"26","26-820 O'Malley No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",415
 "26","26-820 O'Malley No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",429
 "26","26-820 O'Malley No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",525
 "26","26-820 O'Malley No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",511
@@ -13715,8 +13715,8 @@
 "26","26-825 Independence Park No. 2 ","State House","26","REP ","Birch, Chris ",404
 "26","26-825 Independence Park No. 2 ","State House","26","DEM ","Gillespie, David M.  ",246
 "26","26-825 Independence Park No. 2 ","State House","26","NP ","Write-in 30 ",4
-"26","26-825 Independence Park No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",425
-"26","26-825 Independence Park No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",248
+"26","26-825 Independence Park No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",425
+"26","26-825 Independence Park No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",248
 "26","26-825 Independence Park No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",265
 "26","26-825 Independence Park No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",387
 "26","26-825 Independence Park No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",331
@@ -13783,8 +13783,8 @@
 "26","26-830 Elmore No. 2 ","State House","26","REP ","Birch, Chris ",268
 "26","26-830 Elmore No. 2 ","State House","26","DEM ","Gillespie, David M.  ",129
 "26","26-830 Elmore No. 2 ","State House","26","NP ","Write-in 30 ",3
-"26","26-830 Elmore No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",249
-"26","26-830 Elmore No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",161
+"26","26-830 Elmore No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",249
+"26","26-830 Elmore No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",161
 "26","26-830 Elmore No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",165
 "26","26-830 Elmore No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",240
 "26","26-830 Elmore No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",197
@@ -13851,8 +13851,8 @@
 "26","26-835 O'Malley No. 3 ","State House","26","REP ","Birch, Chris ",192
 "26","26-835 O'Malley No. 3 ","State House","26","DEM ","Gillespie, David M.  ",147
 "26","26-835 O'Malley No. 3 ","State House","26","NP ","Write-in 30 ",2
-"26","26-835 O'Malley No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",235
-"26","26-835 O'Malley No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",122
+"26","26-835 O'Malley No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",235
+"26","26-835 O'Malley No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",122
 "26","26-835 O'Malley No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",141
 "26","26-835 O'Malley No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",206
 "26","26-835 O'Malley No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",177
@@ -13922,8 +13922,8 @@
 "27","27-900 Cheney Lake ","State House","27","REP ","Pruitt, Lance ",532
 "27","27-900 Cheney Lake ","State House","27","DEM ","Crawford, Harry T. J ",477
 "27","27-900 Cheney Lake ","State House","27","NP ","Write-in 30 ",7
-"27","27-900 Cheney Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",600
-"27","27-900 Cheney Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",428
+"27","27-900 Cheney Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",600
+"27","27-900 Cheney Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",428
 "27","27-900 Cheney Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",432
 "27","27-900 Cheney Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",565
 "27","27-900 Cheney Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",540
@@ -13993,8 +13993,8 @@
 "27","27-905 Muldoon No. 3 ","State House","27","REP ","Pruitt, Lance ",275
 "27","27-905 Muldoon No. 3 ","State House","27","DEM ","Crawford, Harry T. J ",236
 "27","27-905 Muldoon No. 3 ","State House","27","NP ","Write-in 30 ",3
-"27","27-905 Muldoon No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",309
-"27","27-905 Muldoon No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",215
+"27","27-905 Muldoon No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",309
+"27","27-905 Muldoon No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",215
 "27","27-905 Muldoon No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",220
 "27","27-905 Muldoon No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",294
 "27","27-905 Muldoon No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",273
@@ -14064,8 +14064,8 @@
 "27","27-910 Muldoon No. 4 ","State House","27","REP ","Pruitt, Lance ",472
 "27","27-910 Muldoon No. 4 ","State House","27","DEM ","Crawford, Harry T. J ",401
 "27","27-910 Muldoon No. 4 ","State House","27","NP ","Write-in 30 ",6
-"27","27-910 Muldoon No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",546
-"27","27-910 Muldoon No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",343
+"27","27-910 Muldoon No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",546
+"27","27-910 Muldoon No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",343
 "27","27-910 Muldoon No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",369
 "27","27-910 Muldoon No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",498
 "27","27-910 Muldoon No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",455
@@ -14135,8 +14135,8 @@
 "27","27-915 Chugach Ft. Hills No. 1 ","State House","27","REP ","Pruitt, Lance ",283
 "27","27-915 Chugach Ft. Hills No. 1 ","State House","27","DEM ","Crawford, Harry T. J ",229
 "27","27-915 Chugach Ft. Hills No. 1 ","State House","27","NP ","Write-in 30 ",1
-"27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",335
-"27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",181
+"27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",335
+"27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",181
 "27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",208
 "27","27-915 Chugach Ft. Hills No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",291
 "27","27-915 Chugach Ft. Hills No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",254
@@ -14206,8 +14206,8 @@
 "27","27-920 Chugach Ft. Hills No. 2 ","State House","27","REP ","Pruitt, Lance ",386
 "27","27-920 Chugach Ft. Hills No. 2 ","State House","27","DEM ","Crawford, Harry T. J ",412
 "27","27-920 Chugach Ft. Hills No. 2 ","State House","27","NP ","Write-in 30 ",3
-"27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",497
-"27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",309
+"27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",497
+"27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",309
 "27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",356
 "27","27-920 Chugach Ft. Hills No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",436
 "27","27-920 Chugach Ft. Hills No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",419
@@ -14277,8 +14277,8 @@
 "27","27-925 Scenic Park ","State House","27","REP ","Pruitt, Lance ",346
 "27","27-925 Scenic Park ","State House","27","DEM ","Crawford, Harry T. J ",322
 "27","27-925 Scenic Park ","State House","27","NP ","Write-in 30 ",3
-"27","27-925 Scenic Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",418
-"27","27-925 Scenic Park ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",263
+"27","27-925 Scenic Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",418
+"27","27-925 Scenic Park ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",263
 "27","27-925 Scenic Park ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",274
 "27","27-925 Scenic Park ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",369
 "27","27-925 Scenic Park ","Supreme Crt-Justice Bolger ","","NP ","YES ",331
@@ -14348,8 +14348,8 @@
 "27","27-930 Baxter ","State House","27","REP ","Pruitt, Lance ",524
 "27","27-930 Baxter ","State House","27","DEM ","Crawford, Harry T. J ",572
 "27","27-930 Baxter ","State House","27","NP ","Write-in 30 ",8
-"27","27-930 Baxter ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",707
-"27","27-930 Baxter ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",411
+"27","27-930 Baxter ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",707
+"27","27-930 Baxter ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",411
 "27","27-930 Baxter ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",488
 "27","27-930 Baxter ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",593
 "27","27-930 Baxter ","Supreme Crt-Justice Bolger ","","NP ","YES ",590
@@ -14419,8 +14419,8 @@
 "27","27-935 Stuckagain Heights ","State House","27","REP ","Pruitt, Lance ",102
 "27","27-935 Stuckagain Heights ","State House","27","DEM ","Crawford, Harry T. J ",104
 "27","27-935 Stuckagain Heights ","State House","27","NP ","Write-in 30 ",0
-"27","27-935 Stuckagain Heights ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",122
-"27","27-935 Stuckagain Heights ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",87
+"27","27-935 Stuckagain Heights ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",122
+"27","27-935 Stuckagain Heights ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",87
 "27","27-935 Stuckagain Heights ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",111
 "27","27-935 Stuckagain Heights ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",92
 "27","27-935 Stuckagain Heights ","Supreme Crt-Justice Bolger ","","NP ","YES ",139
@@ -14490,8 +14490,8 @@
 "28","28-105 Rabbit Creek No. 1 ","State House","28","REP ","Johnston, Jennifer B ",474
 "28","28-105 Rabbit Creek No. 1 ","State House","28","DEM ","Cote, Shirley A.  ",325
 "28","28-105 Rabbit Creek No. 1 ","State House","28","NP ","Write-in 30 ",2
-"28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",493
-"28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",319
+"28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",493
+"28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",319
 "28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",349
 "28","28-105 Rabbit Creek No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",441
 "28","28-105 Rabbit Creek No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",422
@@ -14561,8 +14561,8 @@
 "28","28-110 Rabbit Creek No. 2 ","State House","28","REP ","Johnston, Jennifer B ",679
 "28","28-110 Rabbit Creek No. 2 ","State House","28","DEM ","Cote, Shirley A.  ",448
 "28","28-110 Rabbit Creek No. 2 ","State House","28","NP ","Write-in 30 ",3
-"28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",670
-"28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",510
+"28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",670
+"28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",510
 "28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",499
 "28","28-110 Rabbit Creek No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",643
 "28","28-110 Rabbit Creek No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",584
@@ -14632,8 +14632,8 @@
 "28","28-115 Huffman No. 6 ","State House","28","REP ","Johnston, Jennifer B ",487
 "28","28-115 Huffman No. 6 ","State House","28","DEM ","Cote, Shirley A.  ",231
 "28","28-115 Huffman No. 6 ","State House","28","NP ","Write-in 30 ",3
-"28","28-115 Huffman No. 6 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",386
-"28","28-115 Huffman No. 6 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",363
+"28","28-115 Huffman No. 6 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",386
+"28","28-115 Huffman No. 6 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",363
 "28","28-115 Huffman No. 6 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",269
 "28","28-115 Huffman No. 6 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",452
 "28","28-115 Huffman No. 6 ","Supreme Crt-Justice Bolger ","","NP ","YES ",360
@@ -14703,8 +14703,8 @@
 "28","28-120 Huffman No. 7 ","State House","28","REP ","Johnston, Jennifer B ",480
 "28","28-120 Huffman No. 7 ","State House","28","DEM ","Cote, Shirley A.  ",331
 "28","28-120 Huffman No. 7 ","State House","28","NP ","Write-in 30 ",4
-"28","28-120 Huffman No. 7 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",456
-"28","28-120 Huffman No. 7 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",379
+"28","28-120 Huffman No. 7 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",456
+"28","28-120 Huffman No. 7 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",379
 "28","28-120 Huffman No. 7 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",339
 "28","28-120 Huffman No. 7 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",472
 "28","28-120 Huffman No. 7 ","Supreme Crt-Justice Bolger ","","NP ","YES ",452
@@ -14774,8 +14774,8 @@
 "28","28-125 Bear Valley ","State House","28","REP ","Johnston, Jennifer B ",272
 "28","28-125 Bear Valley ","State House","28","DEM ","Cote, Shirley A.  ",262
 "28","28-125 Bear Valley ","State House","28","NP ","Write-in 30 ",4
-"28","28-125 Bear Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",325
-"28","28-125 Bear Valley ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",227
+"28","28-125 Bear Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",325
+"28","28-125 Bear Valley ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",227
 "28","28-125 Bear Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",251
 "28","28-125 Bear Valley ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",289
 "28","28-125 Bear Valley ","Supreme Crt-Justice Bolger ","","NP ","YES ",280
@@ -14845,8 +14845,8 @@
 "28","28-130 Indian ","State House","28","REP ","Johnston, Jennifer B ",70
 "28","28-130 Indian ","State House","28","DEM ","Cote, Shirley A.  ",72
 "28","28-130 Indian ","State House","28","NP ","Write-in 30 ",0
-"28","28-130 Indian ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",84
-"28","28-130 Indian ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",62
+"28","28-130 Indian ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",84
+"28","28-130 Indian ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",62
 "28","28-130 Indian ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",66
 "28","28-130 Indian ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",78
 "28","28-130 Indian ","Supreme Crt-Justice Bolger ","","NP ","YES ",61
@@ -14916,8 +14916,8 @@
 "28","28-135 Girdwood ","State House","28","REP ","Johnston, Jennifer B ",307
 "28","28-135 Girdwood ","State House","28","DEM ","Cote, Shirley A.  ",491
 "28","28-135 Girdwood ","State House","28","NP ","Write-in 30 ",4
-"28","28-135 Girdwood ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",594
-"28","28-135 Girdwood ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",225
+"28","28-135 Girdwood ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",594
+"28","28-135 Girdwood ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",225
 "28","28-135 Girdwood ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",462
 "28","28-135 Girdwood ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",315
 "28","28-135 Girdwood ","Supreme Crt-Justice Bolger ","","NP ","YES ",409
@@ -14987,8 +14987,8 @@
 "28","28-140 Golden View ","State House","28","REP ","Johnston, Jennifer B ",720
 "28","28-140 Golden View ","State House","28","DEM ","Cote, Shirley A.  ",456
 "28","28-140 Golden View ","State House","28","NP ","Write-in 30 ",8
-"28","28-140 Golden View ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",709
-"28","28-140 Golden View ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",504
+"28","28-140 Golden View ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",709
+"28","28-140 Golden View ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",504
 "28","28-140 Golden View ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",535
 "28","28-140 Golden View ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",633
 "28","28-140 Golden View ","Supreme Crt-Justice Bolger ","","NP ","YES ",657
@@ -15058,8 +15058,8 @@
 "28","28-145 O'Malley No. 4 ","State House","28","REP ","Johnston, Jennifer B ",432
 "28","28-145 O'Malley No. 4 ","State House","28","DEM ","Cote, Shirley A.  ",303
 "28","28-145 O'Malley No. 4 ","State House","28","NP ","Write-in 30 ",3
-"28","28-145 O'Malley No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",442
-"28","28-145 O'Malley No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",320
+"28","28-145 O'Malley No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",442
+"28","28-145 O'Malley No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",320
 "28","28-145 O'Malley No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",345
 "28","28-145 O'Malley No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",403
 "28","28-145 O'Malley No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",407
@@ -15125,8 +15125,8 @@
 "29","29-100 Bear Creek ","U.S. House","1","NP ","Write-in 50 ",1
 "29","29-100 Bear Creek ","State House","29","REP ","Chenault, Charles M. ",431
 "29","29-100 Bear Creek ","State House","29","NP ","Write-in 20 ",45
-"29","29-100 Bear Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",406
-"29","29-100 Bear Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",218
+"29","29-100 Bear Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",406
+"29","29-100 Bear Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",218
 "29","29-100 Bear Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",271
 "29","29-100 Bear Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",326
 "29","29-100 Bear Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",301
@@ -15192,8 +15192,8 @@
 "29","29-110 Cooper Landing ","U.S. House","1","NP ","Write-in 50 ",0
 "29","29-110 Cooper Landing ","State House","29","REP ","Chenault, Charles M. ",88
 "29","29-110 Cooper Landing ","State House","29","NP ","Write-in 20 ",10
-"29","29-110 Cooper Landing ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",62
-"29","29-110 Cooper Landing ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",66
+"29","29-110 Cooper Landing ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",62
+"29","29-110 Cooper Landing ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",66
 "29","29-110 Cooper Landing ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",56
 "29","29-110 Cooper Landing ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",70
 "29","29-110 Cooper Landing ","Supreme Crt-Justice Bolger ","","NP ","YES ",65
@@ -15259,8 +15259,8 @@
 "29","29-115 Funny River No. 1 ","U.S. House","1","NP ","Write-in 50 ",0
 "29","29-115 Funny River No. 1 ","State House","29","REP ","Chenault, Charles M. ",249
 "29","29-115 Funny River No. 1 ","State House","29","NP ","Write-in 20 ",14
-"29","29-115 Funny River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",181
-"29","29-115 Funny River No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",144
+"29","29-115 Funny River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",181
+"29","29-115 Funny River No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",144
 "29","29-115 Funny River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",97
 "29","29-115 Funny River No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",219
 "29","29-115 Funny River No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",116
@@ -15326,8 +15326,8 @@
 "29","29-120 Hope ","U.S. House","1","NP ","Write-in 50 ",0
 "29","29-120 Hope ","State House","29","REP ","Chenault, Charles M. ",31
 "29","29-120 Hope ","State House","29","NP ","Write-in 20 ",18
-"29","29-120 Hope ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",44
-"29","29-120 Hope ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"29","29-120 Hope ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",44
+"29","29-120 Hope ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "29","29-120 Hope ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",31
 "29","29-120 Hope ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",38
 "29","29-120 Hope ","Supreme Crt-Justice Bolger ","","NP ","YES ",42
@@ -15393,8 +15393,8 @@
 "29","29-130 Mackey Lake ","U.S. House","1","NP ","Write-in 50 ",4
 "29","29-130 Mackey Lake ","State House","29","REP ","Chenault, Charles M. ",286
 "29","29-130 Mackey Lake ","State House","29","NP ","Write-in 20 ",26
-"29","29-130 Mackey Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",194
-"29","29-130 Mackey Lake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",182
+"29","29-130 Mackey Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",194
+"29","29-130 Mackey Lake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",182
 "29","29-130 Mackey Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",101
 "29","29-130 Mackey Lake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",263
 "29","29-130 Mackey Lake ","Supreme Crt-Justice Bolger ","","NP ","YES ",140
@@ -15460,8 +15460,8 @@
 "29","29-140 Moose Pass ","U.S. House","1","NP ","Write-in 50 ",1
 "29","29-140 Moose Pass ","State House","29","REP ","Chenault, Charles M. ",89
 "29","29-140 Moose Pass ","State House","29","NP ","Write-in 20 ",11
-"29","29-140 Moose Pass ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",96
-"29","29-140 Moose Pass ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",49
+"29","29-140 Moose Pass ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",96
+"29","29-140 Moose Pass ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",49
 "29","29-140 Moose Pass ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",74
 "29","29-140 Moose Pass ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",64
 "29","29-140 Moose Pass ","Supreme Crt-Justice Bolger ","","NP ","YES ",67
@@ -15527,8 +15527,8 @@
 "29","29-150 Nikiski ","U.S. House","1","NP ","Write-in 50 ",6
 "29","29-150 Nikiski ","State House","29","REP ","Chenault, Charles M. ",652
 "29","29-150 Nikiski ","State House","29","NP ","Write-in 20 ",75
-"29","29-150 Nikiski ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",444
-"29","29-150 Nikiski ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",395
+"29","29-150 Nikiski ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",444
+"29","29-150 Nikiski ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",395
 "29","29-150 Nikiski ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",209
 "29","29-150 Nikiski ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",603
 "29","29-150 Nikiski ","Supreme Crt-Justice Bolger ","","NP ","YES ",256
@@ -15594,8 +15594,8 @@
 "29","29-160 Salamatof ","U.S. House","1","NP ","Write-in 50 ",5
 "29","29-160 Salamatof ","State House","29","REP ","Chenault, Charles M. ",759
 "29","29-160 Salamatof ","State House","29","NP ","Write-in 20 ",65
-"29","29-160 Salamatof ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",501
-"29","29-160 Salamatof ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",430
+"29","29-160 Salamatof ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",501
+"29","29-160 Salamatof ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",430
 "29","29-160 Salamatof ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",245
 "29","29-160 Salamatof ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",669
 "29","29-160 Salamatof ","Supreme Crt-Justice Bolger ","","NP ","YES ",305
@@ -15661,8 +15661,8 @@
 "29","29-170 Seward-Lowell Point ","U.S. House","1","NP ","Write-in 50 ",4
 "29","29-170 Seward-Lowell Point ","State House","29","REP ","Chenault, Charles M. ",384
 "29","29-170 Seward-Lowell Point ","State House","29","NP ","Write-in 20 ",55
-"29","29-170 Seward-Lowell Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",438
-"29","29-170 Seward-Lowell Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",155
+"29","29-170 Seward-Lowell Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",438
+"29","29-170 Seward-Lowell Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",155
 "29","29-170 Seward-Lowell Point ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",306
 "29","29-170 Seward-Lowell Point ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",253
 "29","29-170 Seward-Lowell Point ","Supreme Crt-Justice Bolger ","","NP ","YES ",329
@@ -15728,8 +15728,8 @@
 "29","29-180 Sterling No. 1 ","U.S. House","1","NP ","Write-in 50 ",4
 "29","29-180 Sterling No. 1 ","State House","29","REP ","Chenault, Charles M. ",522
 "29","29-180 Sterling No. 1 ","State House","29","NP ","Write-in 20 ",24
-"29","29-180 Sterling No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",339
-"29","29-180 Sterling No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",303
+"29","29-180 Sterling No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",339
+"29","29-180 Sterling No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",303
 "29","29-180 Sterling No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",177
 "29","29-180 Sterling No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",424
 "29","29-180 Sterling No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",209
@@ -15795,8 +15795,8 @@
 "29","29-190 Sterling No. 2 ","U.S. House","1","NP ","Write-in 50 ",2
 "29","29-190 Sterling No. 2 ","State House","29","REP ","Chenault, Charles M. ",623
 "29","29-190 Sterling No. 2 ","State House","29","NP ","Write-in 20 ",49
-"29","29-190 Sterling No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",427
-"29","29-190 Sterling No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",364
+"29","29-190 Sterling No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",427
+"29","29-190 Sterling No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",364
 "29","29-190 Sterling No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",201
 "29","29-190 Sterling No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",547
 "29","29-190 Sterling No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",271
@@ -15865,8 +15865,8 @@
 "30","30-200 Central ","State House","30","CON ","Myers, J. R.  ",39
 "30","30-200 Central ","State House","30","REP ","Knopp, Gary A.  ",484
 "30","30-200 Central ","State House","30","NP ","Write-in 50 ",4
-"30","30-200 Central ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",408
-"30","30-200 Central ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",281
+"30","30-200 Central ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",408
+"30","30-200 Central ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",281
 "30","30-200 Central ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",227
 "30","30-200 Central ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",440
 "30","30-200 Central ","Supreme Crt-Justice Bolger ","","NP ","YES ",258
@@ -15935,8 +15935,8 @@
 "30","30-210 K-Beach ","State House","30","CON ","Myers, J. R.  ",71
 "30","30-210 K-Beach ","State House","30","REP ","Knopp, Gary A.  ",728
 "30","30-210 K-Beach ","State House","30","NP ","Write-in 50 ",5
-"30","30-210 K-Beach ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",632
-"30","30-210 K-Beach ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",428
+"30","30-210 K-Beach ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",632
+"30","30-210 K-Beach ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",428
 "30","30-210 K-Beach ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",356
 "30","30-210 K-Beach ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",674
 "30","30-210 K-Beach ","Supreme Crt-Justice Bolger ","","NP ","YES ",431
@@ -16005,8 +16005,8 @@
 "30","30-220 Kenai No. 1 ","State House","30","CON ","Myers, J. R.  ",52
 "30","30-220 Kenai No. 1 ","State House","30","REP ","Knopp, Gary A.  ",563
 "30","30-220 Kenai No. 1 ","State House","30","NP ","Write-in 50 ",4
-"30","30-220 Kenai No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",559
-"30","30-220 Kenai No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",377
+"30","30-220 Kenai No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",559
+"30","30-220 Kenai No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",377
 "30","30-220 Kenai No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",337
 "30","30-220 Kenai No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",564
 "30","30-220 Kenai No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",386
@@ -16075,8 +16075,8 @@
 "30","30-230 Kenai No. 2 ","State House","30","CON ","Myers, J. R.  ",28
 "30","30-230 Kenai No. 2 ","State House","30","REP ","Knopp, Gary A.  ",295
 "30","30-230 Kenai No. 2 ","State House","30","NP ","Write-in 50 ",1
-"30","30-230 Kenai No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",288
-"30","30-230 Kenai No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",222
+"30","30-230 Kenai No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",288
+"30","30-230 Kenai No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",222
 "30","30-230 Kenai No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",169
 "30","30-230 Kenai No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",325
 "30","30-230 Kenai No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",199
@@ -16145,8 +16145,8 @@
 "30","30-240 Kenai No. 3 ","State House","30","CON ","Myers, J. R.  ",28
 "30","30-240 Kenai No. 3 ","State House","30","REP ","Knopp, Gary A.  ",345
 "30","30-240 Kenai No. 3 ","State House","30","NP ","Write-in 50 ",0
-"30","30-240 Kenai No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",294
-"30","30-240 Kenai No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",230
+"30","30-240 Kenai No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",294
+"30","30-240 Kenai No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",230
 "30","30-240 Kenai No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",171
 "30","30-240 Kenai No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",333
 "30","30-240 Kenai No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",213
@@ -16215,8 +16215,8 @@
 "30","30-250 Soldotna ","State House","30","CON ","Myers, J. R.  ",97
 "30","30-250 Soldotna ","State House","30","REP ","Knopp, Gary A.  ",955
 "30","30-250 Soldotna ","State House","30","NP ","Write-in 50 ",3
-"30","30-250 Soldotna ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",870
-"30","30-250 Soldotna ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",591
+"30","30-250 Soldotna ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",870
+"30","30-250 Soldotna ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",591
 "30","30-250 Soldotna ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",529
 "30","30-250 Soldotna ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",889
 "30","30-250 Soldotna ","Supreme Crt-Justice Bolger ","","NP ","YES ",598
@@ -16284,8 +16284,8 @@
 "31","31-300 Anchor Point ","State Senate","P","NP ","Write-in 20 ",33
 "31","31-300 Anchor Point ","State House","31","REP ","Seaton, Paul ",626
 "31","31-300 Anchor Point ","State House","31","NP ","Write-in 20 ",55
-"31","31-300 Anchor Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",436
-"31","31-300 Anchor Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",409
+"31","31-300 Anchor Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",436
+"31","31-300 Anchor Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",409
 "31","31-300 Anchor Point ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",258
 "31","31-300 Anchor Point ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",542
 "31","31-300 Anchor Point ","Supreme Crt-Justice Bolger ","","NP ","YES ",282
@@ -16353,8 +16353,8 @@
 "31","31-310 Diamond Ridge ","State Senate","P","NP ","Write-in 20 ",12
 "31","31-310 Diamond Ridge ","State House","31","REP ","Seaton, Paul ",326
 "31","31-310 Diamond Ridge ","State House","31","NP ","Write-in 20 ",10
-"31","31-310 Diamond Ridge ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",275
-"31","31-310 Diamond Ridge ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",120
+"31","31-310 Diamond Ridge ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",275
+"31","31-310 Diamond Ridge ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",120
 "31","31-310 Diamond Ridge ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",209
 "31","31-310 Diamond Ridge ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",162
 "31","31-310 Diamond Ridge ","Supreme Crt-Justice Bolger ","","NP ","YES ",191
@@ -16422,8 +16422,8 @@
 "31","31-320 Fox River ","State Senate","P","NP ","Write-in 20 ",5
 "31","31-320 Fox River ","State House","31","REP ","Seaton, Paul ",154
 "31","31-320 Fox River ","State House","31","NP ","Write-in 20 ",11
-"31","31-320 Fox River ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",116
-"31","31-320 Fox River ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",75
+"31","31-320 Fox River ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",116
+"31","31-320 Fox River ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",75
 "31","31-320 Fox River ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",81
 "31","31-320 Fox River ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",102
 "31","31-320 Fox River ","Supreme Crt-Justice Bolger ","","NP ","YES ",83
@@ -16491,8 +16491,8 @@
 "31","31-340 Funny River No. 2 ","State Senate","P","NP ","Write-in 20 ",15
 "31","31-340 Funny River No. 2 ","State House","31","REP ","Seaton, Paul ",436
 "31","31-340 Funny River No. 2 ","State House","31","NP ","Write-in 20 ",13
-"31","31-340 Funny River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",313
-"31","31-340 Funny River No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",256
+"31","31-340 Funny River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",313
+"31","31-340 Funny River No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",256
 "31","31-340 Funny River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",161
 "31","31-340 Funny River No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",394
 "31","31-340 Funny River No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",182
@@ -16560,8 +16560,8 @@
 "31","31-350 Homer No. 1 ","State Senate","P","NP ","Write-in 20 ",15
 "31","31-350 Homer No. 1 ","State House","31","REP ","Seaton, Paul ",739
 "31","31-350 Homer No. 1 ","State House","31","NP ","Write-in 20 ",27
-"31","31-350 Homer No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",568
-"31","31-350 Homer No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",296
+"31","31-350 Homer No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",568
+"31","31-350 Homer No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",296
 "31","31-350 Homer No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",392
 "31","31-350 Homer No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",433
 "31","31-350 Homer No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",376
@@ -16629,8 +16629,8 @@
 "31","31-360 Homer No. 2 ","State Senate","P","NP ","Write-in 20 ",17
 "31","31-360 Homer No. 2 ","State House","31","REP ","Seaton, Paul ",585
 "31","31-360 Homer No. 2 ","State House","31","NP ","Write-in 20 ",20
-"31","31-360 Homer No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",485
-"31","31-360 Homer No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",220
+"31","31-360 Homer No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",485
+"31","31-360 Homer No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",220
 "31","31-360 Homer No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",339
 "31","31-360 Homer No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",339
 "31","31-360 Homer No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",302
@@ -16698,8 +16698,8 @@
 "31","31-370 Kachemak/Fritz Creek ","State Senate","P","NP ","Write-in 20 ",20
 "31","31-370 Kachemak/Fritz Creek ","State House","31","REP ","Seaton, Paul ",565
 "31","31-370 Kachemak/Fritz Creek ","State House","31","NP ","Write-in 20 ",22
-"31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",492
-"31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",203
+"31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",492
+"31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",203
 "31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",344
 "31","31-370 Kachemak/Fritz Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",318
 "31","31-370 Kachemak/Fritz Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",335
@@ -16767,8 +16767,8 @@
 "31","31-380 Kasilof ","State Senate","P","NP ","Write-in 20 ",30
 "31","31-380 Kasilof ","State House","31","REP ","Seaton, Paul ",773
 "31","31-380 Kasilof ","State House","31","NP ","Write-in 20 ",30
-"31","31-380 Kasilof ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",558
-"31","31-380 Kasilof ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",460
+"31","31-380 Kasilof ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",558
+"31","31-380 Kasilof ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",460
 "31","31-380 Kasilof ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",355
 "31","31-380 Kasilof ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",626
 "31","31-380 Kasilof ","Supreme Crt-Justice Bolger ","","NP ","YES ",387
@@ -16836,8 +16836,8 @@
 "31","31-390 Ninilchik ","State Senate","P","NP ","Write-in 20 ",23
 "31","31-390 Ninilchik ","State House","31","REP ","Seaton, Paul ",405
 "31","31-390 Ninilchik ","State House","31","NP ","Write-in 20 ",22
-"31","31-390 Ninilchik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",299
-"31","31-390 Ninilchik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",240
+"31","31-390 Ninilchik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",299
+"31","31-390 Ninilchik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",240
 "31","31-390 Ninilchik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",167
 "31","31-390 Ninilchik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",352
 "31","31-390 Ninilchik ","Supreme Crt-Justice Bolger ","","NP ","YES ",200
@@ -16907,8 +16907,8 @@
 "32","32-800 Chiniak ","State House","32","REP ","Stutes, Louise ",23
 "32","32-800 Chiniak ","State House","32","DEM ","Watkins, Brent L.  ",5
 "32","32-800 Chiniak ","State House","32","NP ","Write-in 40 ",0
-"32","32-800 Chiniak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",43
-"32","32-800 Chiniak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",15
+"32","32-800 Chiniak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",43
+"32","32-800 Chiniak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",15
 "32","32-800 Chiniak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",27
 "32","32-800 Chiniak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",28
 "32","32-800 Chiniak ","Supreme Crt-Justice Bolger ","","NP ","YES ",35
@@ -16978,8 +16978,8 @@
 "32","32-805 Cordova ","State House","32","REP ","Stutes, Louise ",314
 "32","32-805 Cordova ","State House","32","DEM ","Watkins, Brent L.  ",112
 "32","32-805 Cordova ","State House","32","NP ","Write-in 40 ",0
-"32","32-805 Cordova ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",459
-"32","32-805 Cordova ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",173
+"32","32-805 Cordova ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",459
+"32","32-805 Cordova ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",173
 "32","32-805 Cordova ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",325
 "32","32-805 Cordova ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",285
 "32","32-805 Cordova ","Supreme Crt-Justice Bolger ","","NP ","YES ",357
@@ -17049,8 +17049,8 @@
 "32","32-810 Flats ","State House","32","REP ","Stutes, Louise ",210
 "32","32-810 Flats ","State House","32","DEM ","Watkins, Brent L.  ",74
 "32","32-810 Flats ","State House","32","NP ","Write-in 40 ",3
-"32","32-810 Flats ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",347
-"32","32-810 Flats ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",147
+"32","32-810 Flats ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",347
+"32","32-810 Flats ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",147
 "32","32-810 Flats ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",200
 "32","32-810 Flats ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",259
 "32","32-810 Flats ","Supreme Crt-Justice Bolger ","","NP ","YES ",281
@@ -17120,8 +17120,8 @@
 "32","32-815 Kodiak Island South ","State House","32","REP ","Stutes, Louise ",2
 "32","32-815 Kodiak Island South ","State House","32","DEM ","Watkins, Brent L.  ",0
 "32","32-815 Kodiak Island South ","State House","32","NP ","Write-in 40 ",0
-"32","32-815 Kodiak Island South ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",18
-"32","32-815 Kodiak Island South ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"32","32-815 Kodiak Island South ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",18
+"32","32-815 Kodiak Island South ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "32","32-815 Kodiak Island South ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",14
 "32","32-815 Kodiak Island South ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "32","32-815 Kodiak Island South ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -17191,8 +17191,8 @@
 "32","32-820 Kodiak No. 1 ","State House","32","REP ","Stutes, Louise ",317
 "32","32-820 Kodiak No. 1 ","State House","32","DEM ","Watkins, Brent L.  ",93
 "32","32-820 Kodiak No. 1 ","State House","32","NP ","Write-in 40 ",1
-"32","32-820 Kodiak No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",491
-"32","32-820 Kodiak No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",200
+"32","32-820 Kodiak No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",491
+"32","32-820 Kodiak No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",200
 "32","32-820 Kodiak No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",333
 "32","32-820 Kodiak No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",319
 "32","32-820 Kodiak No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",461
@@ -17262,8 +17262,8 @@
 "32","32-825 Kodiak No. 2 ","State House","32","REP ","Stutes, Louise ",335
 "32","32-825 Kodiak No. 2 ","State House","32","DEM ","Watkins, Brent L.  ",98
 "32","32-825 Kodiak No. 2 ","State House","32","NP ","Write-in 40 ",0
-"32","32-825 Kodiak No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",493
-"32","32-825 Kodiak No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",167
+"32","32-825 Kodiak No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",493
+"32","32-825 Kodiak No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",167
 "32","32-825 Kodiak No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",354
 "32","32-825 Kodiak No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",283
 "32","32-825 Kodiak No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",438
@@ -17333,8 +17333,8 @@
 "32","32-830 Mission Road ","State House","32","REP ","Stutes, Louise ",566
 "32","32-830 Mission Road ","State House","32","DEM ","Watkins, Brent L.  ",145
 "32","32-830 Mission Road ","State House","32","NP ","Write-in 40 ",2
-"32","32-830 Mission Road ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",983
-"32","32-830 Mission Road ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",407
+"32","32-830 Mission Road ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",983
+"32","32-830 Mission Road ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",407
 "32","32-830 Mission Road ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",609
 "32","32-830 Mission Road ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",730
 "32","32-830 Mission Road ","Supreme Crt-Justice Bolger ","","NP ","YES ",889
@@ -17404,8 +17404,8 @@
 "32","32-835 Old Harbor ","State House","32","REP ","Stutes, Louise ",11
 "32","32-835 Old Harbor ","State House","32","DEM ","Watkins, Brent L.  ",4
 "32","32-835 Old Harbor ","State House","32","NP ","Write-in 40 ",0
-"32","32-835 Old Harbor ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",46
-"32","32-835 Old Harbor ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",2
+"32","32-835 Old Harbor ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",46
+"32","32-835 Old Harbor ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",2
 "32","32-835 Old Harbor ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",29
 "32","32-835 Old Harbor ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",18
 "32","32-835 Old Harbor ","Supreme Crt-Justice Bolger ","","NP ","YES ",36
@@ -17475,8 +17475,8 @@
 "32","32-840 Ouzinkie ","State House","32","REP ","Stutes, Louise ",11
 "32","32-840 Ouzinkie ","State House","32","DEM ","Watkins, Brent L.  ",5
 "32","32-840 Ouzinkie ","State House","32","NP ","Write-in 40 ",0
-"32","32-840 Ouzinkie ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",33
-"32","32-840 Ouzinkie ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",25
+"32","32-840 Ouzinkie ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",33
+"32","32-840 Ouzinkie ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",25
 "32","32-840 Ouzinkie ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",27
 "32","32-840 Ouzinkie ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",29
 "32","32-840 Ouzinkie ","Supreme Crt-Justice Bolger ","","NP ","YES ",36
@@ -17546,8 +17546,8 @@
 "32","32-845 Port Lions ","State House","32","REP ","Stutes, Louise ",22
 "32","32-845 Port Lions ","State House","32","DEM ","Watkins, Brent L.  ",3
 "32","32-845 Port Lions ","State House","32","NP ","Write-in 40 ",0
-"32","32-845 Port Lions ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",40
-"32","32-845 Port Lions ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",16
+"32","32-845 Port Lions ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",40
+"32","32-845 Port Lions ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",16
 "32","32-845 Port Lions ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",26
 "32","32-845 Port Lions ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",30
 "32","32-845 Port Lions ","Supreme Crt-Justice Bolger ","","NP ","YES ",38
@@ -17617,8 +17617,8 @@
 "32","32-847 Seldovia/Kachemak Bay ","State House","32","REP ","Stutes, Louise ",69
 "32","32-847 Seldovia/Kachemak Bay ","State House","32","DEM ","Watkins, Brent L.  ",48
 "32","32-847 Seldovia/Kachemak Bay ","State House","32","NP ","Write-in 40 ",1
-"32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",103
-"32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",43
+"32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",103
+"32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",43
 "32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",70
 "32","32-847 Seldovia/Kachemak Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",66
 "32","32-847 Seldovia/Kachemak Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",58
@@ -17688,8 +17688,8 @@
 "32","32-850 Tatitlek ","State House","32","REP ","Stutes, Louise ",5
 "32","32-850 Tatitlek ","State House","32","DEM ","Watkins, Brent L.  ",10
 "32","32-850 Tatitlek ","State House","32","NP ","Write-in 40 ",0
-"32","32-850 Tatitlek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",12
-"32","32-850 Tatitlek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"32","32-850 Tatitlek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",12
+"32","32-850 Tatitlek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "32","32-850 Tatitlek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",8
 "32","32-850 Tatitlek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",13
 "32","32-850 Tatitlek ","Supreme Crt-Justice Bolger ","","NP ","YES ",10
@@ -17759,8 +17759,8 @@
 "32","32-855 Tyonek ","State House","32","REP ","Stutes, Louise ",8
 "32","32-855 Tyonek ","State House","32","DEM ","Watkins, Brent L.  ",20
 "32","32-855 Tyonek ","State House","32","NP ","Write-in 40 ",1
-"32","32-855 Tyonek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",27
-"32","32-855 Tyonek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",16
+"32","32-855 Tyonek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",27
+"32","32-855 Tyonek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",16
 "32","32-855 Tyonek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",17
 "32","32-855 Tyonek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "32","32-855 Tyonek ","Supreme Crt-Justice Bolger ","","NP ","YES ",26
@@ -17830,8 +17830,8 @@
 "32","32-860 Yakutat ","State House","32","REP ","Stutes, Louise ",88
 "32","32-860 Yakutat ","State House","32","DEM ","Watkins, Brent L.  ",52
 "32","32-860 Yakutat ","State House","32","NP ","Write-in 40 ",0
-"32","32-860 Yakutat ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",152
-"32","32-860 Yakutat ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",55
+"32","32-860 Yakutat ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",152
+"32","32-860 Yakutat ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",55
 "32","32-860 Yakutat ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",108
 "32","32-860 Yakutat ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",88
 "32","32-860 Yakutat ","Supreme Crt-Justice Bolger ","","NP ","YES ",107
@@ -17869,8 +17869,8 @@
 "33","33-500 Douglas ","U.S. House","1","NP ","Write-in 50 ",1
 "33","33-500 Douglas ","State House","33","DEM ","Kito, Sam S. III ",567
 "33","33-500 Douglas ","State House","33","NP ","Write-in 20 ",14
-"33","33-500 Douglas ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",504
-"33","33-500 Douglas ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",191
+"33","33-500 Douglas ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",504
+"33","33-500 Douglas ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",191
 "33","33-500 Douglas ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",415
 "33","33-500 Douglas ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",251
 "33","33-500 Douglas ","Supreme Crt-Justice Bolger ","","NP ","YES ",455
@@ -17908,8 +17908,8 @@
 "33","33-505 Gustavus ","U.S. House","1","NP ","Write-in 50 ",0
 "33","33-505 Gustavus ","State House","33","DEM ","Kito, Sam S. III ",174
 "33","33-505 Gustavus ","State House","33","NP ","Write-in 20 ",9
-"33","33-505 Gustavus ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",156
-"33","33-505 Gustavus ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",43
+"33","33-505 Gustavus ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",156
+"33","33-505 Gustavus ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",43
 "33","33-505 Gustavus ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",103
 "33","33-505 Gustavus ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",91
 "33","33-505 Gustavus ","Supreme Crt-Justice Bolger ","","NP ","YES ",120
@@ -17947,8 +17947,8 @@
 "33","33-510 Juneau No. 1 ","U.S. House","1","NP ","Write-in 50 ",2
 "33","33-510 Juneau No. 1 ","State House","33","DEM ","Kito, Sam S. III ",493
 "33","33-510 Juneau No. 1 ","State House","33","NP ","Write-in 20 ",34
-"33","33-510 Juneau No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",449
-"33","33-510 Juneau No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",156
+"33","33-510 Juneau No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",449
+"33","33-510 Juneau No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",156
 "33","33-510 Juneau No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",351
 "33","33-510 Juneau No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",229
 "33","33-510 Juneau No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",375
@@ -17986,8 +17986,8 @@
 "33","33-515 Juneau No. 2 ","U.S. House","1","NP ","Write-in 50 ",1
 "33","33-515 Juneau No. 2 ","State House","33","DEM ","Kito, Sam S. III ",706
 "33","33-515 Juneau No. 2 ","State House","33","NP ","Write-in 20 ",24
-"33","33-515 Juneau No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",608
-"33","33-515 Juneau No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",212
+"33","33-515 Juneau No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",608
+"33","33-515 Juneau No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",212
 "33","33-515 Juneau No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",541
 "33","33-515 Juneau No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",254
 "33","33-515 Juneau No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",601
@@ -18025,8 +18025,8 @@
 "33","33-520 Juneau No. 3 ","U.S. House","1","NP ","Write-in 50 ",2
 "33","33-520 Juneau No. 3 ","State House","33","DEM ","Kito, Sam S. III ",279
 "33","33-520 Juneau No. 3 ","State House","33","NP ","Write-in 20 ",10
-"33","33-520 Juneau No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",261
-"33","33-520 Juneau No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",89
+"33","33-520 Juneau No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",261
+"33","33-520 Juneau No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",89
 "33","33-520 Juneau No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",202
 "33","33-520 Juneau No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",131
 "33","33-520 Juneau No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",219
@@ -18064,8 +18064,8 @@
 "33","33-525 Lemon Creek ","U.S. House","1","NP ","Write-in 50 ",4
 "33","33-525 Lemon Creek ","State House","33","DEM ","Kito, Sam S. III ",485
 "33","33-525 Lemon Creek ","State House","33","NP ","Write-in 20 ",35
-"33","33-525 Lemon Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",433
-"33","33-525 Lemon Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",217
+"33","33-525 Lemon Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",433
+"33","33-525 Lemon Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",217
 "33","33-525 Lemon Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",319
 "33","33-525 Lemon Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",308
 "33","33-525 Lemon Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",383
@@ -18103,8 +18103,8 @@
 "33","33-530 North Douglas ","U.S. House","1","NP ","Write-in 50 ",0
 "33","33-530 North Douglas ","State House","33","DEM ","Kito, Sam S. III ",483
 "33","33-530 North Douglas ","State House","33","NP ","Write-in 20 ",15
-"33","33-530 North Douglas ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",427
-"33","33-530 North Douglas ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",151
+"33","33-530 North Douglas ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",427
+"33","33-530 North Douglas ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",151
 "33","33-530 North Douglas ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",337
 "33","33-530 North Douglas ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",208
 "33","33-530 North Douglas ","Supreme Crt-Justice Bolger ","","NP ","YES ",372
@@ -18142,8 +18142,8 @@
 "33","33-540 Skagway ","U.S. House","1","NP ","Write-in 50 ",0
 "33","33-540 Skagway ","State House","33","DEM ","Kito, Sam S. III ",360
 "33","33-540 Skagway ","State House","33","NP ","Write-in 20 ",9
-"33","33-540 Skagway ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",331
-"33","33-540 Skagway ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",107
+"33","33-540 Skagway ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",331
+"33","33-540 Skagway ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",107
 "33","33-540 Skagway ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",238
 "33","33-540 Skagway ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",183
 "33","33-540 Skagway ","Supreme Crt-Justice Bolger ","","NP ","YES ",253
@@ -18181,8 +18181,8 @@
 "33","33-545 Haines No. 1 ","U.S. House","1","NP ","Write-in 50 ",1
 "33","33-545 Haines No. 1 ","State House","33","DEM ","Kito, Sam S. III ",604
 "33","33-545 Haines No. 1 ","State House","33","NP ","Write-in 20 ",34
-"33","33-545 Haines No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",539
-"33","33-545 Haines No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",229
+"33","33-545 Haines No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",539
+"33","33-545 Haines No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",229
 "33","33-545 Haines No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",373
 "33","33-545 Haines No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",361
 "33","33-545 Haines No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",409
@@ -18220,8 +18220,8 @@
 "33","33-550 Haines No. 2 ","U.S. House","1","NP ","Write-in 50 ",0
 "33","33-550 Haines No. 2 ","State House","33","DEM ","Kito, Sam S. III ",66
 "33","33-550 Haines No. 2 ","State House","33","NP ","Write-in 20 ",5
-"33","33-550 Haines No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",58
-"33","33-550 Haines No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",36
+"33","33-550 Haines No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",58
+"33","33-550 Haines No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",36
 "33","33-550 Haines No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",45
 "33","33-550 Haines No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "33","33-550 Haines No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -18259,8 +18259,8 @@
 "33","33-555 Klukwan ","U.S. House","1","NP ","Write-in 50 ",0
 "33","33-555 Klukwan ","State House","33","DEM ","Kito, Sam S. III ",40
 "33","33-555 Klukwan ","State House","33","NP ","Write-in 20 ",0
-"33","33-555 Klukwan ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",23
-"33","33-555 Klukwan ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",18
+"33","33-555 Klukwan ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",23
+"33","33-555 Klukwan ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",18
 "33","33-555 Klukwan ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",12
 "33","33-555 Klukwan ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",28
 "33","33-555 Klukwan ","Supreme Crt-Justice Bolger ","","NP ","YES ",23
@@ -18296,11 +18296,11 @@
 "34","34-400 Auke Bay ","U.S. House","1","NA ","Souphanavong, Bernie ",11
 "34","34-400 Auke Bay ","U.S. House","1","REP ","Young, Don ",284
 "34","34-400 Auke Bay ","U.S. House","1","NP ","Write-in 50 ",1
-"34","34-400 Auke Bay ","State House","34","REP ","Muñoz, Cathy ",330
+"34","34-400 Auke Bay ","State House","34","REP ","MuÃ±oz, Cathy ",330
 "34","34-400 Auke Bay ","State House","34","DEM ","Parish, Justin ",282
 "34","34-400 Auke Bay ","State House","34","NP ","Write-in 30 ",2
-"34","34-400 Auke Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",411
-"34","34-400 Auke Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",199
+"34","34-400 Auke Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",411
+"34","34-400 Auke Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",199
 "34","34-400 Auke Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",323
 "34","34-400 Auke Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",276
 "34","34-400 Auke Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",369
@@ -18336,11 +18336,11 @@
 "34","34-410 Juneau Airport ","U.S. House","1","NA ","Souphanavong, Bernie ",10
 "34","34-410 Juneau Airport ","U.S. House","1","REP ","Young, Don ",241
 "34","34-410 Juneau Airport ","U.S. House","1","NP ","Write-in 50 ",0
-"34","34-410 Juneau Airport ","State House","34","REP ","Muñoz, Cathy ",245
+"34","34-410 Juneau Airport ","State House","34","REP ","MuÃ±oz, Cathy ",245
 "34","34-410 Juneau Airport ","State House","34","DEM ","Parish, Justin ",230
 "34","34-410 Juneau Airport ","State House","34","NP ","Write-in 30 ",4
-"34","34-410 Juneau Airport ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",327
-"34","34-410 Juneau Airport ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",153
+"34","34-410 Juneau Airport ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",327
+"34","34-410 Juneau Airport ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",153
 "34","34-410 Juneau Airport ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",254
 "34","34-410 Juneau Airport ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",208
 "34","34-410 Juneau Airport ","Supreme Crt-Justice Bolger ","","NP ","YES ",285
@@ -18376,11 +18376,11 @@
 "34","34-420 Lynn Canal ","U.S. House","1","NA ","Souphanavong, Bernie ",9
 "34","34-420 Lynn Canal ","U.S. House","1","REP ","Young, Don ",201
 "34","34-420 Lynn Canal ","U.S. House","1","NP ","Write-in 50 ",2
-"34","34-420 Lynn Canal ","State House","34","REP ","Muñoz, Cathy ",228
+"34","34-420 Lynn Canal ","State House","34","REP ","MuÃ±oz, Cathy ",228
 "34","34-420 Lynn Canal ","State House","34","DEM ","Parish, Justin ",300
 "34","34-420 Lynn Canal ","State House","34","NP ","Write-in 30 ",2
-"34","34-420 Lynn Canal ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",370
-"34","34-420 Lynn Canal ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",164
+"34","34-420 Lynn Canal ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",370
+"34","34-420 Lynn Canal ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",164
 "34","34-420 Lynn Canal ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",291
 "34","34-420 Lynn Canal ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",226
 "34","34-420 Lynn Canal ","Supreme Crt-Justice Bolger ","","NP ","YES ",366
@@ -18416,11 +18416,11 @@
 "34","34-430 Mendenhall Valley No. 1 ","U.S. House","1","NA ","Souphanavong, Bernie ",22
 "34","34-430 Mendenhall Valley No. 1 ","U.S. House","1","REP ","Young, Don ",260
 "34","34-430 Mendenhall Valley No. 1 ","U.S. House","1","NP ","Write-in 50 ",2
-"34","34-430 Mendenhall Valley No. 1 ","State House","34","REP ","Muñoz, Cathy ",271
+"34","34-430 Mendenhall Valley No. 1 ","State House","34","REP ","MuÃ±oz, Cathy ",271
 "34","34-430 Mendenhall Valley No. 1 ","State House","34","DEM ","Parish, Justin ",292
 "34","34-430 Mendenhall Valley No. 1 ","State House","34","NP ","Write-in 30 ",2
-"34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",404
-"34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",169
+"34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",404
+"34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",169
 "34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",279
 "34","34-430 Mendenhall Valley No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",277
 "34","34-430 Mendenhall Valley No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",366
@@ -18456,11 +18456,11 @@
 "34","34-440 Mendenhall Valley No. 2 ","U.S. House","1","NA ","Souphanavong, Bernie ",25
 "34","34-440 Mendenhall Valley No. 2 ","U.S. House","1","REP ","Young, Don ",399
 "34","34-440 Mendenhall Valley No. 2 ","U.S. House","1","NP ","Write-in 50 ",3
-"34","34-440 Mendenhall Valley No. 2 ","State House","34","REP ","Muñoz, Cathy ",412
+"34","34-440 Mendenhall Valley No. 2 ","State House","34","REP ","MuÃ±oz, Cathy ",412
 "34","34-440 Mendenhall Valley No. 2 ","State House","34","DEM ","Parish, Justin ",399
 "34","34-440 Mendenhall Valley No. 2 ","State House","34","NP ","Write-in 30 ",3
-"34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",551
-"34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",258
+"34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",551
+"34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",258
 "34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",377
 "34","34-440 Mendenhall Valley No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",398
 "34","34-440 Mendenhall Valley No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",491
@@ -18496,11 +18496,11 @@
 "34","34-450 Mendenhall Valley No. 3 ","U.S. House","1","NA ","Souphanavong, Bernie ",24
 "34","34-450 Mendenhall Valley No. 3 ","U.S. House","1","REP ","Young, Don ",341
 "34","34-450 Mendenhall Valley No. 3 ","U.S. House","1","NP ","Write-in 50 ",5
-"34","34-450 Mendenhall Valley No. 3 ","State House","34","REP ","Muñoz, Cathy ",384
+"34","34-450 Mendenhall Valley No. 3 ","State House","34","REP ","MuÃ±oz, Cathy ",384
 "34","34-450 Mendenhall Valley No. 3 ","State House","34","DEM ","Parish, Justin ",340
 "34","34-450 Mendenhall Valley No. 3 ","State House","34","NP ","Write-in 30 ",4
-"34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",485
-"34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",237
+"34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",485
+"34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",237
 "34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",340
 "34","34-450 Mendenhall Valley No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",352
 "34","34-450 Mendenhall Valley No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",421
@@ -18536,11 +18536,11 @@
 "34","34-460 Mendenhall Valley No. 4 ","U.S. House","1","NA ","Souphanavong, Bernie ",26
 "34","34-460 Mendenhall Valley No. 4 ","U.S. House","1","REP ","Young, Don ",488
 "34","34-460 Mendenhall Valley No. 4 ","U.S. House","1","NP ","Write-in 50 ",8
-"34","34-460 Mendenhall Valley No. 4 ","State House","34","REP ","Muñoz, Cathy ",532
+"34","34-460 Mendenhall Valley No. 4 ","State House","34","REP ","MuÃ±oz, Cathy ",532
 "34","34-460 Mendenhall Valley No. 4 ","State House","34","DEM ","Parish, Justin ",465
 "34","34-460 Mendenhall Valley No. 4 ","State House","34","NP ","Write-in 30 ",9
-"34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",663
-"34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",339
+"34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",663
+"34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",339
 "34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",480
 "34","34-460 Mendenhall Valley No. 4 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",501
 "34","34-460 Mendenhall Valley No. 4 ","Supreme Crt-Justice Bolger ","","NP ","YES ",592
@@ -18581,8 +18581,8 @@
 "35","35-700 Angoon ","State House","35","REP ","Finkenbinder, Sheila ",24
 "35","35-700 Angoon ","State House","35","DEM ","Kreiss-Tomkins, Jona ",151
 "35","35-700 Angoon ","State House","35","NP ","Write-in 30 ",1
-"35","35-700 Angoon ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",106
-"35","35-700 Angoon ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",69
+"35","35-700 Angoon ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",106
+"35","35-700 Angoon ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",69
 "35","35-700 Angoon ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",91
 "35","35-700 Angoon ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",83
 "35","35-700 Angoon ","Supreme Crt-Justice Bolger ","","NP ","YES ",104
@@ -18623,8 +18623,8 @@
 "35","35-705 Craig ","State House","35","REP ","Finkenbinder, Sheila ",206
 "35","35-705 Craig ","State House","35","DEM ","Kreiss-Tomkins, Jona ",199
 "35","35-705 Craig ","State House","35","NP ","Write-in 30 ",2
-"35","35-705 Craig ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",269
-"35","35-705 Craig ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",141
+"35","35-705 Craig ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",269
+"35","35-705 Craig ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",141
 "35","35-705 Craig ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",196
 "35","35-705 Craig ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",196
 "35","35-705 Craig ","Supreme Crt-Justice Bolger ","","NP ","YES ",214
@@ -18665,8 +18665,8 @@
 "35","35-720 Hoonah ","State House","35","REP ","Finkenbinder, Sheila ",98
 "35","35-720 Hoonah ","State House","35","DEM ","Kreiss-Tomkins, Jona ",199
 "35","35-720 Hoonah ","State House","35","NP ","Write-in 30 ",2
-"35","35-720 Hoonah ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",232
-"35","35-720 Hoonah ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",68
+"35","35-720 Hoonah ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",232
+"35","35-720 Hoonah ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",68
 "35","35-720 Hoonah ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",152
 "35","35-720 Hoonah ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",140
 "35","35-720 Hoonah ","Supreme Crt-Justice Bolger ","","NP ","YES ",151
@@ -18707,8 +18707,8 @@
 "35","35-730 Kake ","State House","35","REP ","Finkenbinder, Sheila ",50
 "35","35-730 Kake ","State House","35","DEM ","Kreiss-Tomkins, Jona ",128
 "35","35-730 Kake ","State House","35","NP ","Write-in 30 ",1
-"35","35-730 Kake ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",134
-"35","35-730 Kake ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",46
+"35","35-730 Kake ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",134
+"35","35-730 Kake ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",46
 "35","35-730 Kake ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",94
 "35","35-730 Kake ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",83
 "35","35-730 Kake ","Supreme Crt-Justice Bolger ","","NP ","YES ",86
@@ -18749,8 +18749,8 @@
 "35","35-735 Kasaan ","State House","35","REP ","Finkenbinder, Sheila ",7
 "35","35-735 Kasaan ","State House","35","DEM ","Kreiss-Tomkins, Jona ",15
 "35","35-735 Kasaan ","State House","35","NP ","Write-in 30 ",0
-"35","35-735 Kasaan ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",14
-"35","35-735 Kasaan ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",7
+"35","35-735 Kasaan ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",14
+"35","35-735 Kasaan ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",7
 "35","35-735 Kasaan ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",5
 "35","35-735 Kasaan ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "35","35-735 Kasaan ","Supreme Crt-Justice Bolger ","","NP ","YES ",8
@@ -18791,8 +18791,8 @@
 "35","35-740 Klawock ","State House","35","REP ","Finkenbinder, Sheila ",103
 "35","35-740 Klawock ","State House","35","DEM ","Kreiss-Tomkins, Jona ",176
 "35","35-740 Klawock ","State House","35","NP ","Write-in 30 ",0
-"35","35-740 Klawock ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",208
-"35","35-740 Klawock ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",82
+"35","35-740 Klawock ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",208
+"35","35-740 Klawock ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",82
 "35","35-740 Klawock ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",137
 "35","35-740 Klawock ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",143
 "35","35-740 Klawock ","Supreme Crt-Justice Bolger ","","NP ","YES ",155
@@ -18833,8 +18833,8 @@
 "35","35-745 North Prince of Wales ","State House","35","REP ","Finkenbinder, Sheila ",55
 "35","35-745 North Prince of Wales ","State House","35","DEM ","Kreiss-Tomkins, Jona ",32
 "35","35-745 North Prince of Wales ","State House","35","NP ","Write-in 30 ",2
-"35","35-745 North Prince of Wales ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",57
-"35","35-745 North Prince of Wales ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",35
+"35","35-745 North Prince of Wales ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",57
+"35","35-745 North Prince of Wales ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",35
 "35","35-745 North Prince of Wales ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",40
 "35","35-745 North Prince of Wales ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",49
 "35","35-745 North Prince of Wales ","Supreme Crt-Justice Bolger ","","NP ","YES ",51
@@ -18875,8 +18875,8 @@
 "35","35-750 Pelican-Elfin Cove ","State House","35","REP ","Finkenbinder, Sheila ",18
 "35","35-750 Pelican-Elfin Cove ","State House","35","DEM ","Kreiss-Tomkins, Jona ",24
 "35","35-750 Pelican-Elfin Cove ","State House","35","NP ","Write-in 30 ",0
-"35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",30
-"35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",18
+"35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",30
+"35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",18
 "35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",27
 "35","35-750 Pelican-Elfin Cove ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",19
 "35","35-750 Pelican-Elfin Cove ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -18917,8 +18917,8 @@
 "35","35-755 Petersburg-Kupreanof ","State House","35","REP ","Finkenbinder, Sheila ",469
 "35","35-755 Petersburg-Kupreanof ","State House","35","DEM ","Kreiss-Tomkins, Jona ",557
 "35","35-755 Petersburg-Kupreanof ","State House","35","NP ","Write-in 30 ",4
-"35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",693
-"35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",324
+"35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",693
+"35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",324
 "35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",495
 "35","35-755 Petersburg-Kupreanof ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",467
 "35","35-755 Petersburg-Kupreanof ","Supreme Crt-Justice Bolger ","","NP ","YES ",561
@@ -18959,8 +18959,8 @@
 "35","35-760 Port Alexander ","State House","35","REP ","Finkenbinder, Sheila ",6
 "35","35-760 Port Alexander ","State House","35","DEM ","Kreiss-Tomkins, Jona ",19
 "35","35-760 Port Alexander ","State House","35","NP ","Write-in 30 ",0
-"35","35-760 Port Alexander ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",20
-"35","35-760 Port Alexander ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",7
+"35","35-760 Port Alexander ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",20
+"35","35-760 Port Alexander ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",7
 "35","35-760 Port Alexander ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",17
 "35","35-760 Port Alexander ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",8
 "35","35-760 Port Alexander ","Supreme Crt-Justice Bolger ","","NP ","YES ",12
@@ -19001,8 +19001,8 @@
 "35","35-765 Sitka No. 1 ","State House","35","REP ","Finkenbinder, Sheila ",568
 "35","35-765 Sitka No. 1 ","State House","35","DEM ","Kreiss-Tomkins, Jona ",819
 "35","35-765 Sitka No. 1 ","State House","35","NP ","Write-in 30 ",1
-"35","35-765 Sitka No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1027
-"35","35-765 Sitka No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",351
+"35","35-765 Sitka No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1027
+"35","35-765 Sitka No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",351
 "35","35-765 Sitka No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",692
 "35","35-765 Sitka No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",629
 "35","35-765 Sitka No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",808
@@ -19043,8 +19043,8 @@
 "35","35-770 Sitka No. 2 ","State House","35","REP ","Finkenbinder, Sheila ",463
 "35","35-770 Sitka No. 2 ","State House","35","DEM ","Kreiss-Tomkins, Jona ",882
 "35","35-770 Sitka No. 2 ","State House","35","NP ","Write-in 30 ",4
-"35","35-770 Sitka No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1028
-"35","35-770 Sitka No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",288
+"35","35-770 Sitka No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1028
+"35","35-770 Sitka No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",288
 "35","35-770 Sitka No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",742
 "35","35-770 Sitka No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",521
 "35","35-770 Sitka No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",805
@@ -19085,8 +19085,8 @@
 "35","35-775 Tenakee Springs ","State House","35","REP ","Finkenbinder, Sheila ",17
 "35","35-775 Tenakee Springs ","State House","35","DEM ","Kreiss-Tomkins, Jona ",42
 "35","35-775 Tenakee Springs ","State House","35","NP ","Write-in 30 ",0
-"35","35-775 Tenakee Springs ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",37
-"35","35-775 Tenakee Springs ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",20
+"35","35-775 Tenakee Springs ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",37
+"35","35-775 Tenakee Springs ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",20
 "35","35-775 Tenakee Springs ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",27
 "35","35-775 Tenakee Springs ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "35","35-775 Tenakee Springs ","Supreme Crt-Justice Bolger ","","NP ","YES ",30
@@ -19127,8 +19127,8 @@
 "35","35-780 Thorne Bay ","State House","35","REP ","Finkenbinder, Sheila ",105
 "35","35-780 Thorne Bay ","State House","35","DEM ","Kreiss-Tomkins, Jona ",62
 "35","35-780 Thorne Bay ","State House","35","NP ","Write-in 30 ",0
-"35","35-780 Thorne Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",101
-"35","35-780 Thorne Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",72
+"35","35-780 Thorne Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",101
+"35","35-780 Thorne Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",72
 "35","35-780 Thorne Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",53
 "35","35-780 Thorne Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",114
 "35","35-780 Thorne Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",86
@@ -19170,8 +19170,8 @@
 "36","36-600 Ketchikan No. 1 ","State House","36","REP ","Sivertsen, Robert W. ",240
 "36","36-600 Ketchikan No. 1 ","State House","36","NA ","Ortiz, Daniel H.  ",395
 "36","36-600 Ketchikan No. 1 ","State House","36","NP ","Write-in 40 ",1
-"36","36-600 Ketchikan No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",447
-"36","36-600 Ketchikan No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",220
+"36","36-600 Ketchikan No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",447
+"36","36-600 Ketchikan No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",220
 "36","36-600 Ketchikan No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",313
 "36","36-600 Ketchikan No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",328
 "36","36-600 Ketchikan No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",409
@@ -19213,8 +19213,8 @@
 "36","36-610 Ketchikan No. 2 ","State House","36","REP ","Sivertsen, Robert W. ",352
 "36","36-610 Ketchikan No. 2 ","State House","36","NA ","Ortiz, Daniel H.  ",527
 "36","36-610 Ketchikan No. 2 ","State House","36","NP ","Write-in 40 ",0
-"36","36-610 Ketchikan No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",641
-"36","36-610 Ketchikan No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",270
+"36","36-610 Ketchikan No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",641
+"36","36-610 Ketchikan No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",270
 "36","36-610 Ketchikan No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",449
 "36","36-610 Ketchikan No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",422
 "36","36-610 Ketchikan No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",533
@@ -19256,8 +19256,8 @@
 "36","36-620 Ketchikan No. 3 ","State House","36","REP ","Sivertsen, Robert W. ",307
 "36","36-620 Ketchikan No. 3 ","State House","36","NA ","Ortiz, Daniel H.  ",305
 "36","36-620 Ketchikan No. 3 ","State House","36","NP ","Write-in 40 ",3
-"36","36-620 Ketchikan No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",436
-"36","36-620 Ketchikan No. 3 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",202
+"36","36-620 Ketchikan No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",436
+"36","36-620 Ketchikan No. 3 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",202
 "36","36-620 Ketchikan No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",281
 "36","36-620 Ketchikan No. 3 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",338
 "36","36-620 Ketchikan No. 3 ","Supreme Crt-Justice Bolger ","","NP ","YES ",399
@@ -19299,8 +19299,8 @@
 "36","36-640 North Tongass No. 1 ","State House","36","REP ","Sivertsen, Robert W. ",190
 "36","36-640 North Tongass No. 1 ","State House","36","NA ","Ortiz, Daniel H.  ",163
 "36","36-640 North Tongass No. 1 ","State House","36","NP ","Write-in 40 ",0
-"36","36-640 North Tongass No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",252
-"36","36-640 North Tongass No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",123
+"36","36-640 North Tongass No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",252
+"36","36-640 North Tongass No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",123
 "36","36-640 North Tongass No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "36","36-640 North Tongass No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",239
 "36","36-640 North Tongass No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",208
@@ -19342,8 +19342,8 @@
 "36","36-650 North Tongass No. 2 ","State House","36","REP ","Sivertsen, Robert W. ",370
 "36","36-650 North Tongass No. 2 ","State House","36","NA ","Ortiz, Daniel H.  ",378
 "36","36-650 North Tongass No. 2 ","State House","36","NP ","Write-in 40 ",0
-"36","36-650 North Tongass No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",493
-"36","36-650 North Tongass No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",276
+"36","36-650 North Tongass No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",493
+"36","36-650 North Tongass No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",276
 "36","36-650 North Tongass No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",282
 "36","36-650 North Tongass No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",458
 "36","36-650 North Tongass No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",449
@@ -19385,8 +19385,8 @@
 "36","36-660 Saxman ","State House","36","REP ","Sivertsen, Robert W. ",45
 "36","36-660 Saxman ","State House","36","NA ","Ortiz, Daniel H.  ",64
 "36","36-660 Saxman ","State House","36","NP ","Write-in 40 ",0
-"36","36-660 Saxman ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",80
-"36","36-660 Saxman ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",39
+"36","36-660 Saxman ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",80
+"36","36-660 Saxman ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",39
 "36","36-660 Saxman ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",53
 "36","36-660 Saxman ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",66
 "36","36-660 Saxman ","Supreme Crt-Justice Bolger ","","NP ","YES ",56
@@ -19428,8 +19428,8 @@
 "36","36-670 South Tongass ","State House","36","REP ","Sivertsen, Robert W. ",297
 "36","36-670 South Tongass ","State House","36","NA ","Ortiz, Daniel H.  ",331
 "36","36-670 South Tongass ","State House","36","NP ","Write-in 40 ",1
-"36","36-670 South Tongass ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",439
-"36","36-670 South Tongass ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",215
+"36","36-670 South Tongass ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",439
+"36","36-670 South Tongass ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",215
 "36","36-670 South Tongass ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",266
 "36","36-670 South Tongass ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",351
 "36","36-670 South Tongass ","Supreme Crt-Justice Bolger ","","NP ","YES ",401
@@ -19471,8 +19471,8 @@
 "36","36-675 Hydaburg ","State House","36","REP ","Sivertsen, Robert W. ",11
 "36","36-675 Hydaburg ","State House","36","NA ","Ortiz, Daniel H.  ",68
 "36","36-675 Hydaburg ","State House","36","NP ","Write-in 40 ",1
-"36","36-675 Hydaburg ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",56
-"36","36-675 Hydaburg ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",30
+"36","36-675 Hydaburg ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",56
+"36","36-675 Hydaburg ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",30
 "36","36-675 Hydaburg ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",46
 "36","36-675 Hydaburg ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "36","36-675 Hydaburg ","Supreme Crt-Justice Bolger ","","NP ","YES ",40
@@ -19514,8 +19514,8 @@
 "36","36-680 Metlakatla ","State House","36","REP ","Sivertsen, Robert W. ",83
 "36","36-680 Metlakatla ","State House","36","NA ","Ortiz, Daniel H.  ",369
 "36","36-680 Metlakatla ","State House","36","NP ","Write-in 40 ",1
-"36","36-680 Metlakatla ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",333
-"36","36-680 Metlakatla ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",139
+"36","36-680 Metlakatla ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",333
+"36","36-680 Metlakatla ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",139
 "36","36-680 Metlakatla ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",219
 "36","36-680 Metlakatla ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",235
 "36","36-680 Metlakatla ","Supreme Crt-Justice Bolger ","","NP ","YES ",250
@@ -19557,8 +19557,8 @@
 "36","36-690 Wrangell ","State House","36","REP ","Sivertsen, Robert W. ",423
 "36","36-690 Wrangell ","State House","36","NA ","Ortiz, Daniel H.  ",295
 "36","36-690 Wrangell ","State House","36","NP ","Write-in 40 ",1
-"36","36-690 Wrangell ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",502
-"36","36-690 Wrangell ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",243
+"36","36-690 Wrangell ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",502
+"36","36-690 Wrangell ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",243
 "36","36-690 Wrangell ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",335
 "36","36-690 Wrangell ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",384
 "36","36-690 Wrangell ","Supreme Crt-Justice Bolger ","","NP ","YES ",393
@@ -19597,8 +19597,8 @@
 "37","37-300 Anvik ","State House","37","DEM ","Edgmon, Bryce E.  ",18
 "37","37-300 Anvik ","State House","37","REP ","Weatherby, William W ",15
 "37","37-300 Anvik ","State House","37","NP ","Write-in 30 ",0
-"37","37-300 Anvik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",21
-"37","37-300 Anvik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"37","37-300 Anvik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",21
+"37","37-300 Anvik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "37","37-300 Anvik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",19
 "37","37-300 Anvik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "37","37-300 Anvik ","Supreme Crt-Justice Bolger ","","NP ","YES ",17
@@ -19645,8 +19645,8 @@
 "37","37-302 Grayling ","State House","37","DEM ","Edgmon, Bryce E.  ",16
 "37","37-302 Grayling ","State House","37","REP ","Weatherby, William W ",38
 "37","37-302 Grayling ","State House","37","NP ","Write-in 30 ",0
-"37","37-302 Grayling ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",38
-"37","37-302 Grayling ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",19
+"37","37-302 Grayling ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",38
+"37","37-302 Grayling ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",19
 "37","37-302 Grayling ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",30
 "37","37-302 Grayling ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",27
 "37","37-302 Grayling ","Supreme Crt-Justice Bolger ","","NP ","YES ",29
@@ -19693,8 +19693,8 @@
 "37","37-304 Holy Cross ","State House","37","DEM ","Edgmon, Bryce E.  ",36
 "37","37-304 Holy Cross ","State House","37","REP ","Weatherby, William W ",28
 "37","37-304 Holy Cross ","State House","37","NP ","Write-in 30 ",0
-"37","37-304 Holy Cross ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",42
-"37","37-304 Holy Cross ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"37","37-304 Holy Cross ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",42
+"37","37-304 Holy Cross ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "37","37-304 Holy Cross ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",30
 "37","37-304 Holy Cross ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",37
 "37","37-304 Holy Cross ","Supreme Crt-Justice Bolger ","","NP ","YES ",30
@@ -19741,8 +19741,8 @@
 "37","37-306 McGrath ","State House","37","DEM ","Edgmon, Bryce E.  ",35
 "37","37-306 McGrath ","State House","37","REP ","Weatherby, William W ",48
 "37","37-306 McGrath ","State House","37","NP ","Write-in 30 ",1
-"37","37-306 McGrath ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"37","37-306 McGrath ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",24
+"37","37-306 McGrath ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"37","37-306 McGrath ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",24
 "37","37-306 McGrath ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",37
 "37","37-306 McGrath ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",49
 "37","37-306 McGrath ","Supreme Crt-Justice Bolger ","","NP ","YES ",47
@@ -19789,8 +19789,8 @@
 "37","37-308 Nikolai ","State House","37","DEM ","Edgmon, Bryce E.  ",18
 "37","37-308 Nikolai ","State House","37","REP ","Weatherby, William W ",18
 "37","37-308 Nikolai ","State House","37","NP ","Write-in 30 ",0
-"37","37-308 Nikolai ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",34
-"37","37-308 Nikolai ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",8
+"37","37-308 Nikolai ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",34
+"37","37-308 Nikolai ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",8
 "37","37-308 Nikolai ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",19
 "37","37-308 Nikolai ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",22
 "37","37-308 Nikolai ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -19837,8 +19837,8 @@
 "37","37-310 Shageluk ","State House","37","DEM ","Edgmon, Bryce E.  ",8
 "37","37-310 Shageluk ","State House","37","REP ","Weatherby, William W ",8
 "37","37-310 Shageluk ","State House","37","NP ","Write-in 30 ",0
-"37","37-310 Shageluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",13
-"37","37-310 Shageluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",3
+"37","37-310 Shageluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",13
+"37","37-310 Shageluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",3
 "37","37-310 Shageluk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",11
 "37","37-310 Shageluk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",5
 "37","37-310 Shageluk ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -19885,8 +19885,8 @@
 "37","37-312 Takotna ","State House","37","DEM ","Edgmon, Bryce E.  ",2
 "37","37-312 Takotna ","State House","37","REP ","Weatherby, William W ",8
 "37","37-312 Takotna ","State House","37","NP ","Write-in 30 ",0
-"37","37-312 Takotna ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",8
-"37","37-312 Takotna ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",2
+"37","37-312 Takotna ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",8
+"37","37-312 Takotna ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",2
 "37","37-312 Takotna ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",3
 "37","37-312 Takotna ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",4
 "37","37-312 Takotna ","Supreme Crt-Justice Bolger ","","NP ","YES ",3
@@ -19933,8 +19933,8 @@
 "37","37-700 Akutan ","State House","37","DEM ","Edgmon, Bryce E.  ",45
 "37","37-700 Akutan ","State House","37","REP ","Weatherby, William W ",23
 "37","37-700 Akutan ","State House","37","NP ","Write-in 30 ",2
-"37","37-700 Akutan ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",54
-"37","37-700 Akutan ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",13
+"37","37-700 Akutan ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",54
+"37","37-700 Akutan ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",13
 "37","37-700 Akutan ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",47
 "37","37-700 Akutan ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",19
 "37","37-700 Akutan ","Supreme Crt-Justice Bolger ","","NP ","YES ",51
@@ -20001,8 +20001,8 @@
 "37","37-702 Aleknagik ","State House","37","DEM ","Edgmon, Bryce E.  ",47
 "37","37-702 Aleknagik ","State House","37","REP ","Weatherby, William W ",11
 "37","37-702 Aleknagik ","State House","37","NP ","Write-in 30 ",0
-"37","37-702 Aleknagik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",38
-"37","37-702 Aleknagik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",20
+"37","37-702 Aleknagik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",38
+"37","37-702 Aleknagik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",20
 "37","37-702 Aleknagik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",21
 "37","37-702 Aleknagik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",36
 "37","37-702 Aleknagik ","Supreme Crt-Justice Bolger ","","NP ","YES ",34
@@ -20069,8 +20069,8 @@
 "37","37-704 Aleutians No. 1 ","State House","37","DEM ","Edgmon, Bryce E.  ",18
 "37","37-704 Aleutians No. 1 ","State House","37","REP ","Weatherby, William W ",9
 "37","37-704 Aleutians No. 1 ","State House","37","NP ","Write-in 30 ",0
-"37","37-704 Aleutians No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",21
-"37","37-704 Aleutians No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"37","37-704 Aleutians No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",21
+"37","37-704 Aleutians No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "37","37-704 Aleutians No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",19
 "37","37-704 Aleutians No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",9
 "37","37-704 Aleutians No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",19
@@ -20137,8 +20137,8 @@
 "37","37-706 Aleutians No. 2 ","State House","37","DEM ","Edgmon, Bryce E.  ",344
 "37","37-706 Aleutians No. 2 ","State House","37","REP ","Weatherby, William W ",315
 "37","37-706 Aleutians No. 2 ","State House","37","NP ","Write-in 30 ",5
-"37","37-706 Aleutians No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",464
-"37","37-706 Aleutians No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",174
+"37","37-706 Aleutians No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",464
+"37","37-706 Aleutians No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",174
 "37","37-706 Aleutians No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",373
 "37","37-706 Aleutians No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",247
 "37","37-706 Aleutians No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",365
@@ -20205,8 +20205,8 @@
 "37","37-708 Chignik ","State House","37","DEM ","Edgmon, Bryce E.  ",10
 "37","37-708 Chignik ","State House","37","REP ","Weatherby, William W ",15
 "37","37-708 Chignik ","State House","37","NP ","Write-in 30 ",0
-"37","37-708 Chignik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",21
-"37","37-708 Chignik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",4
+"37","37-708 Chignik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",21
+"37","37-708 Chignik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",4
 "37","37-708 Chignik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",12
 "37","37-708 Chignik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",12
 "37","37-708 Chignik ","Supreme Crt-Justice Bolger ","","NP ","YES ",17
@@ -20273,8 +20273,8 @@
 "37","37-710 Clark's Point ","State House","37","DEM ","Edgmon, Bryce E.  ",11
 "37","37-710 Clark's Point ","State House","37","REP ","Weatherby, William W ",4
 "37","37-710 Clark's Point ","State House","37","NP ","Write-in 30 ",0
-"37","37-710 Clark's Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",12
-"37","37-710 Clark's Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",3
+"37","37-710 Clark's Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",12
+"37","37-710 Clark's Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",3
 "37","37-710 Clark's Point ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",10
 "37","37-710 Clark's Point ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",4
 "37","37-710 Clark's Point ","Supreme Crt-Justice Bolger ","","NP ","YES ",7
@@ -20341,8 +20341,8 @@
 "37","37-712 Cold Bay ","State House","37","DEM ","Edgmon, Bryce E.  ",2
 "37","37-712 Cold Bay ","State House","37","REP ","Weatherby, William W ",20
 "37","37-712 Cold Bay ","State House","37","NP ","Write-in 30 ",1
-"37","37-712 Cold Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",15
-"37","37-712 Cold Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",7
+"37","37-712 Cold Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",15
+"37","37-712 Cold Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",7
 "37","37-712 Cold Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",9
 "37","37-712 Cold Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",13
 "37","37-712 Cold Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",7
@@ -20409,8 +20409,8 @@
 "37","37-714 Dillingham ","State House","37","DEM ","Edgmon, Bryce E.  ",479
 "37","37-714 Dillingham ","State House","37","REP ","Weatherby, William W ",219
 "37","37-714 Dillingham ","State House","37","NP ","Write-in 30 ",1
-"37","37-714 Dillingham ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",539
-"37","37-714 Dillingham ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",151
+"37","37-714 Dillingham ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",539
+"37","37-714 Dillingham ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",151
 "37","37-714 Dillingham ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",370
 "37","37-714 Dillingham ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",302
 "37","37-714 Dillingham ","Supreme Crt-Justice Bolger ","","NP ","YES ",396
@@ -20477,8 +20477,8 @@
 "37","37-716 Egegik ","State House","37","DEM ","Edgmon, Bryce E.  ",7
 "37","37-716 Egegik ","State House","37","REP ","Weatherby, William W ",3
 "37","37-716 Egegik ","State House","37","NP ","Write-in 30 ",0
-"37","37-716 Egegik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",7
-"37","37-716 Egegik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",3
+"37","37-716 Egegik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",7
+"37","37-716 Egegik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",3
 "37","37-716 Egegik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",5
 "37","37-716 Egegik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",5
 "37","37-716 Egegik ","Supreme Crt-Justice Bolger ","","NP ","YES ",7
@@ -20545,8 +20545,8 @@
 "37","37-718 Ekwok ","State House","37","DEM ","Edgmon, Bryce E.  ",29
 "37","37-718 Ekwok ","State House","37","REP ","Weatherby, William W ",7
 "37","37-718 Ekwok ","State House","37","NP ","Write-in 30 ",0
-"37","37-718 Ekwok ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",30
-"37","37-718 Ekwok ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",4
+"37","37-718 Ekwok ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",30
+"37","37-718 Ekwok ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",4
 "37","37-718 Ekwok ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",22
 "37","37-718 Ekwok ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",15
 "37","37-718 Ekwok ","Supreme Crt-Justice Bolger ","","NP ","YES ",22
@@ -20613,8 +20613,8 @@
 "37","37-720 King Cove ","State House","37","DEM ","Edgmon, Bryce E.  ",55
 "37","37-720 King Cove ","State House","37","REP ","Weatherby, William W ",64
 "37","37-720 King Cove ","State House","37","NP ","Write-in 30 ",0
-"37","37-720 King Cove ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",81
-"37","37-720 King Cove ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",38
+"37","37-720 King Cove ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",81
+"37","37-720 King Cove ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",38
 "37","37-720 King Cove ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",60
 "37","37-720 King Cove ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",49
 "37","37-720 King Cove ","Supreme Crt-Justice Bolger ","","NP ","YES ",56
@@ -20681,8 +20681,8 @@
 "37","37-722 King Salmon ","State House","37","DEM ","Edgmon, Bryce E.  ",76
 "37","37-722 King Salmon ","State House","37","REP ","Weatherby, William W ",44
 "37","37-722 King Salmon ","State House","37","NP ","Write-in 30 ",3
-"37","37-722 King Salmon ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",88
-"37","37-722 King Salmon ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",34
+"37","37-722 King Salmon ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",88
+"37","37-722 King Salmon ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",34
 "37","37-722 King Salmon ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",59
 "37","37-722 King Salmon ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",65
 "37","37-722 King Salmon ","Supreme Crt-Justice Bolger ","","NP ","YES ",62
@@ -20749,8 +20749,8 @@
 "37","37-724 Koliganek ","State House","37","DEM ","Edgmon, Bryce E.  ",19
 "37","37-724 Koliganek ","State House","37","REP ","Weatherby, William W ",4
 "37","37-724 Koliganek ","State House","37","NP ","Write-in 30 ",0
-"37","37-724 Koliganek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",18
-"37","37-724 Koliganek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",6
+"37","37-724 Koliganek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",18
+"37","37-724 Koliganek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",6
 "37","37-724 Koliganek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",13
 "37","37-724 Koliganek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",10
 "37","37-724 Koliganek ","Supreme Crt-Justice Bolger ","","NP ","YES ",7
@@ -20817,8 +20817,8 @@
 "37","37-726 Lake Iliamna No. 1 ","State House","37","DEM ","Edgmon, Bryce E.  ",47
 "37","37-726 Lake Iliamna No. 1 ","State House","37","REP ","Weatherby, William W ",47
 "37","37-726 Lake Iliamna No. 1 ","State House","37","NP ","Write-in 30 ",0
-"37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",72
-"37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",23
+"37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",72
+"37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",23
 "37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",55
 "37","37-726 Lake Iliamna No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",37
 "37","37-726 Lake Iliamna No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",48
@@ -20885,8 +20885,8 @@
 "37","37-728 Lake Iliamna No. 2 ","State House","37","DEM ","Edgmon, Bryce E.  ",15
 "37","37-728 Lake Iliamna No. 2 ","State House","37","REP ","Weatherby, William W ",38
 "37","37-728 Lake Iliamna No. 2 ","State House","37","NP ","Write-in 30 ",0
-"37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",37
-"37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",16
+"37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",37
+"37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",16
 "37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",18
 "37","37-728 Lake Iliamna No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",29
 "37","37-728 Lake Iliamna No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",24
@@ -20953,8 +20953,8 @@
 "37","37-730 Levelock ","State House","37","DEM ","Edgmon, Bryce E.  ",27
 "37","37-730 Levelock ","State House","37","REP ","Weatherby, William W ",8
 "37","37-730 Levelock ","State House","37","NP ","Write-in 30 ",0
-"37","37-730 Levelock ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",27
-"37","37-730 Levelock ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",9
+"37","37-730 Levelock ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",27
+"37","37-730 Levelock ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",9
 "37","37-730 Levelock ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",12
 "37","37-730 Levelock ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",21
 "37","37-730 Levelock ","Supreme Crt-Justice Bolger ","","NP ","YES ",16
@@ -21021,8 +21021,8 @@
 "37","37-732 Manokotak ","State House","37","DEM ","Edgmon, Bryce E.  ",80
 "37","37-732 Manokotak ","State House","37","REP ","Weatherby, William W ",45
 "37","37-732 Manokotak ","State House","37","NP ","Write-in 30 ",0
-"37","37-732 Manokotak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",71
-"37","37-732 Manokotak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",47
+"37","37-732 Manokotak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",71
+"37","37-732 Manokotak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",47
 "37","37-732 Manokotak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",67
 "37","37-732 Manokotak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",58
 "37","37-732 Manokotak ","Supreme Crt-Justice Bolger ","","NP ","YES ",79
@@ -21089,8 +21089,8 @@
 "37","37-734 Naknek ","State House","37","DEM ","Edgmon, Bryce E.  ",116
 "37","37-734 Naknek ","State House","37","REP ","Weatherby, William W ",41
 "37","37-734 Naknek ","State House","37","NP ","Write-in 30 ",13
-"37","37-734 Naknek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",124
-"37","37-734 Naknek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",46
+"37","37-734 Naknek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",124
+"37","37-734 Naknek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",46
 "37","37-734 Naknek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",86
 "37","37-734 Naknek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",75
 "37","37-734 Naknek ","Supreme Crt-Justice Bolger ","","NP ","YES ",90
@@ -21157,8 +21157,8 @@
 "37","37-736 New Stuyahok ","State House","37","DEM ","Edgmon, Bryce E.  ",121
 "37","37-736 New Stuyahok ","State House","37","REP ","Weatherby, William W ",38
 "37","37-736 New Stuyahok ","State House","37","NP ","Write-in 30 ",0
-"37","37-736 New Stuyahok ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",124
-"37","37-736 New Stuyahok ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",38
+"37","37-736 New Stuyahok ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",124
+"37","37-736 New Stuyahok ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",38
 "37","37-736 New Stuyahok ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",105
 "37","37-736 New Stuyahok ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",55
 "37","37-736 New Stuyahok ","Supreme Crt-Justice Bolger ","","NP ","YES ",109
@@ -21225,8 +21225,8 @@
 "37","37-738 Nondalton ","State House","37","DEM ","Edgmon, Bryce E.  ",41
 "37","37-738 Nondalton ","State House","37","REP ","Weatherby, William W ",27
 "37","37-738 Nondalton ","State House","37","NP ","Write-in 30 ",0
-"37","37-738 Nondalton ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",44
-"37","37-738 Nondalton ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",23
+"37","37-738 Nondalton ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",44
+"37","37-738 Nondalton ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",23
 "37","37-738 Nondalton ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",37
 "37","37-738 Nondalton ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",30
 "37","37-738 Nondalton ","Supreme Crt-Justice Bolger ","","NP ","YES ",43
@@ -21293,8 +21293,8 @@
 "37","37-740 Pedro Bay ","State House","37","DEM ","Edgmon, Bryce E.  ",8
 "37","37-740 Pedro Bay ","State House","37","REP ","Weatherby, William W ",10
 "37","37-740 Pedro Bay ","State House","37","NP ","Write-in 30 ",0
-"37","37-740 Pedro Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",16
-"37","37-740 Pedro Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",3
+"37","37-740 Pedro Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",16
+"37","37-740 Pedro Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",3
 "37","37-740 Pedro Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",8
 "37","37-740 Pedro Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",11
 "37","37-740 Pedro Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",10
@@ -21361,8 +21361,8 @@
 "37","37-742 Port Heiden ","State House","37","DEM ","Edgmon, Bryce E.  ",18
 "37","37-742 Port Heiden ","State House","37","REP ","Weatherby, William W ",14
 "37","37-742 Port Heiden ","State House","37","NP ","Write-in 30 ",0
-"37","37-742 Port Heiden ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",23
-"37","37-742 Port Heiden ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"37","37-742 Port Heiden ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",23
+"37","37-742 Port Heiden ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "37","37-742 Port Heiden ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",18
 "37","37-742 Port Heiden ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",14
 "37","37-742 Port Heiden ","Supreme Crt-Justice Bolger ","","NP ","YES ",17
@@ -21429,8 +21429,8 @@
 "37","37-744 Sand Point ","State House","37","DEM ","Edgmon, Bryce E.  ",63
 "37","37-744 Sand Point ","State House","37","REP ","Weatherby, William W ",75
 "37","37-744 Sand Point ","State House","37","NP ","Write-in 30 ",0
-"37","37-744 Sand Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",102
-"37","37-744 Sand Point ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",40
+"37","37-744 Sand Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",102
+"37","37-744 Sand Point ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",40
 "37","37-744 Sand Point ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",70
 "37","37-744 Sand Point ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",61
 "37","37-744 Sand Point ","Supreme Crt-Justice Bolger ","","NP ","YES ",66
@@ -21497,8 +21497,8 @@
 "37","37-746 Sleetmute ","State House","37","DEM ","Edgmon, Bryce E.  ",19
 "37","37-746 Sleetmute ","State House","37","REP ","Weatherby, William W ",11
 "37","37-746 Sleetmute ","State House","37","NP ","Write-in 30 ",0
-"37","37-746 Sleetmute ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",24
-"37","37-746 Sleetmute ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"37","37-746 Sleetmute ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",24
+"37","37-746 Sleetmute ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "37","37-746 Sleetmute ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",17
 "37","37-746 Sleetmute ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",13
 "37","37-746 Sleetmute ","Supreme Crt-Justice Bolger ","","NP ","YES ",16
@@ -21545,8 +21545,8 @@
 "37","37-748 South Naknek ","State House","37","DEM ","Edgmon, Bryce E.  ",10
 "37","37-748 South Naknek ","State House","37","REP ","Weatherby, William W ",9
 "37","37-748 South Naknek ","State House","37","NP ","Write-in 30 ",0
-"37","37-748 South Naknek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",14
-"37","37-748 South Naknek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"37","37-748 South Naknek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",14
+"37","37-748 South Naknek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "37","37-748 South Naknek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",7
 "37","37-748 South Naknek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",11
 "37","37-748 South Naknek ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -21613,8 +21613,8 @@
 "37","37-750 St. George Island ","State House","37","DEM ","Edgmon, Bryce E.  ",10
 "37","37-750 St. George Island ","State House","37","REP ","Weatherby, William W ",6
 "37","37-750 St. George Island ","State House","37","NP ","Write-in 30 ",0
-"37","37-750 St. George Island ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",12
-"37","37-750 St. George Island ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"37","37-750 St. George Island ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",12
+"37","37-750 St. George Island ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "37","37-750 St. George Island ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",9
 "37","37-750 St. George Island ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",7
 "37","37-750 St. George Island ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -21681,8 +21681,8 @@
 "37","37-752 St. Paul Island ","State House","37","DEM ","Edgmon, Bryce E.  ",68
 "37","37-752 St. Paul Island ","State House","37","REP ","Weatherby, William W ",41
 "37","37-752 St. Paul Island ","State House","37","NP ","Write-in 30 ",0
-"37","37-752 St. Paul Island ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",83
-"37","37-752 St. Paul Island ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",28
+"37","37-752 St. Paul Island ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",83
+"37","37-752 St. Paul Island ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",28
 "37","37-752 St. Paul Island ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",54
 "37","37-752 St. Paul Island ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",51
 "37","37-752 St. Paul Island ","Supreme Crt-Justice Bolger ","","NP ","YES ",70
@@ -21749,8 +21749,8 @@
 "37","37-754 Togiak ","State House","37","DEM ","Edgmon, Bryce E.  ",118
 "37","37-754 Togiak ","State House","37","REP ","Weatherby, William W ",67
 "37","37-754 Togiak ","State House","37","NP ","Write-in 30 ",1
-"37","37-754 Togiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",127
-"37","37-754 Togiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",51
+"37","37-754 Togiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",127
+"37","37-754 Togiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",51
 "37","37-754 Togiak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",99
 "37","37-754 Togiak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",84
 "37","37-754 Togiak ","Supreme Crt-Justice Bolger ","","NP ","YES ",97
@@ -21816,8 +21816,8 @@
 "38","38-800 Akiachak ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-800 Akiachak ","State House","38","DEM ","Fansler, Zach ",87
 "38","38-800 Akiachak ","State House","38","NP ","Write-in 20 ",0
-"38","38-800 Akiachak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",60
-"38","38-800 Akiachak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",48
+"38","38-800 Akiachak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",60
+"38","38-800 Akiachak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",48
 "38","38-800 Akiachak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",59
 "38","38-800 Akiachak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",47
 "38","38-800 Akiachak ","Supreme Crt-Justice Bolger ","","NP ","YES ",60
@@ -21863,8 +21863,8 @@
 "38","38-802 Akiak ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-802 Akiak ","State House","38","DEM ","Fansler, Zach ",89
 "38","38-802 Akiak ","State House","38","NP ","Write-in 20 ",2
-"38","38-802 Akiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",40
-"38","38-802 Akiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",58
+"38","38-802 Akiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",40
+"38","38-802 Akiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",58
 "38","38-802 Akiak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",37
 "38","38-802 Akiak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",63
 "38","38-802 Akiak ","Supreme Crt-Justice Bolger ","","NP ","YES ",43
@@ -21910,8 +21910,8 @@
 "38","38-804 Aniak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-804 Aniak ","State House","38","DEM ","Fansler, Zach ",108
 "38","38-804 Aniak ","State House","38","NP ","Write-in 20 ",10
-"38","38-804 Aniak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",99
-"38","38-804 Aniak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",37
+"38","38-804 Aniak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",99
+"38","38-804 Aniak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",37
 "38","38-804 Aniak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",70
 "38","38-804 Aniak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",62
 "38","38-804 Aniak ","Supreme Crt-Justice Bolger ","","NP ","YES ",65
@@ -21957,8 +21957,8 @@
 "38","38-806 Atmautluak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-806 Atmautluak ","State House","38","DEM ","Fansler, Zach ",52
 "38","38-806 Atmautluak ","State House","38","NP ","Write-in 20 ",1
-"38","38-806 Atmautluak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",25
-"38","38-806 Atmautluak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",33
+"38","38-806 Atmautluak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",25
+"38","38-806 Atmautluak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",33
 "38","38-806 Atmautluak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",24
 "38","38-806 Atmautluak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",34
 "38","38-806 Atmautluak ","Supreme Crt-Justice Bolger ","","NP ","YES ",33
@@ -22004,8 +22004,8 @@
 "38","38-808 Bethel No. 1 ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-808 Bethel No. 1 ","State House","38","DEM ","Fansler, Zach ",508
 "38","38-808 Bethel No. 1 ","State House","38","NP ","Write-in 20 ",40
-"38","38-808 Bethel No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",431
-"38","38-808 Bethel No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",164
+"38","38-808 Bethel No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",431
+"38","38-808 Bethel No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",164
 "38","38-808 Bethel No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",332
 "38","38-808 Bethel No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",255
 "38","38-808 Bethel No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",329
@@ -22051,8 +22051,8 @@
 "38","38-810 Bethel No. 2 ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-810 Bethel No. 2 ","State House","38","DEM ","Fansler, Zach ",496
 "38","38-810 Bethel No. 2 ","State House","38","NP ","Write-in 20 ",54
-"38","38-810 Bethel No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",479
-"38","38-810 Bethel No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",136
+"38","38-810 Bethel No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",479
+"38","38-810 Bethel No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",136
 "38","38-810 Bethel No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",350
 "38","38-810 Bethel No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",253
 "38","38-810 Bethel No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",389
@@ -22098,8 +22098,8 @@
 "38","38-812 Chefornak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-812 Chefornak ","State House","38","DEM ","Fansler, Zach ",142
 "38","38-812 Chefornak ","State House","38","NP ","Write-in 20 ",4
-"38","38-812 Chefornak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",91
-"38","38-812 Chefornak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",68
+"38","38-812 Chefornak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",91
+"38","38-812 Chefornak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",68
 "38","38-812 Chefornak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",78
 "38","38-812 Chefornak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",79
 "38","38-812 Chefornak ","Supreme Crt-Justice Bolger ","","NP ","YES ",94
@@ -22145,8 +22145,8 @@
 "38","38-814 Chuathbaluk ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-814 Chuathbaluk ","State House","38","DEM ","Fansler, Zach ",22
 "38","38-814 Chuathbaluk ","State House","38","NP ","Write-in 20 ",1
-"38","38-814 Chuathbaluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",18
-"38","38-814 Chuathbaluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",6
+"38","38-814 Chuathbaluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",18
+"38","38-814 Chuathbaluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",6
 "38","38-814 Chuathbaluk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",9
 "38","38-814 Chuathbaluk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",13
 "38","38-814 Chuathbaluk ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -22192,8 +22192,8 @@
 "38","38-816 Crooked Creek ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-816 Crooked Creek ","State House","38","DEM ","Fansler, Zach ",20
 "38","38-816 Crooked Creek ","State House","38","NP ","Write-in 20 ",0
-"38","38-816 Crooked Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",17
-"38","38-816 Crooked Creek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",8
+"38","38-816 Crooked Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",17
+"38","38-816 Crooked Creek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",8
 "38","38-816 Crooked Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",12
 "38","38-816 Crooked Creek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",12
 "38","38-816 Crooked Creek ","Supreme Crt-Justice Bolger ","","NP ","YES ",13
@@ -22239,8 +22239,8 @@
 "38","38-818 Eek ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-818 Eek ","State House","38","DEM ","Fansler, Zach ",78
 "38","38-818 Eek ","State House","38","NP ","Write-in 20 ",0
-"38","38-818 Eek ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",57
-"38","38-818 Eek ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",30
+"38","38-818 Eek ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",57
+"38","38-818 Eek ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",30
 "38","38-818 Eek ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",42
 "38","38-818 Eek ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "38","38-818 Eek ","Supreme Crt-Justice Bolger ","","NP ","YES ",45
@@ -22286,8 +22286,8 @@
 "38","38-820 Goodnews Bay ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-820 Goodnews Bay ","State House","38","DEM ","Fansler, Zach ",72
 "38","38-820 Goodnews Bay ","State House","38","NP ","Write-in 20 ",0
-"38","38-820 Goodnews Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",47
-"38","38-820 Goodnews Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",32
+"38","38-820 Goodnews Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",47
+"38","38-820 Goodnews Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",32
 "38","38-820 Goodnews Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",42
 "38","38-820 Goodnews Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",38
 "38","38-820 Goodnews Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",42
@@ -22333,8 +22333,8 @@
 "38","38-822 Kasigluk ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-822 Kasigluk ","State House","38","DEM ","Fansler, Zach ",70
 "38","38-822 Kasigluk ","State House","38","NP ","Write-in 20 ",1
-"38","38-822 Kasigluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",52
-"38","38-822 Kasigluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"38","38-822 Kasigluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",52
+"38","38-822 Kasigluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "38","38-822 Kasigluk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",31
 "38","38-822 Kasigluk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",47
 "38","38-822 Kasigluk ","Supreme Crt-Justice Bolger ","","NP ","YES ",53
@@ -22380,8 +22380,8 @@
 "38","38-824 Kipnuk ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-824 Kipnuk ","State House","38","DEM ","Fansler, Zach ",133
 "38","38-824 Kipnuk ","State House","38","NP ","Write-in 20 ",2
-"38","38-824 Kipnuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",93
-"38","38-824 Kipnuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",43
+"38","38-824 Kipnuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",93
+"38","38-824 Kipnuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",43
 "38","38-824 Kipnuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",82
 "38","38-824 Kipnuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",55
 "38","38-824 Kipnuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",79
@@ -22427,8 +22427,8 @@
 "38","38-826 Kongiganak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-826 Kongiganak ","State House","38","DEM ","Fansler, Zach ",83
 "38","38-826 Kongiganak ","State House","38","NP ","Write-in 20 ",3
-"38","38-826 Kongiganak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",49
-"38","38-826 Kongiganak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",37
+"38","38-826 Kongiganak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",49
+"38","38-826 Kongiganak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",37
 "38","38-826 Kongiganak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",45
 "38","38-826 Kongiganak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",41
 "38","38-826 Kongiganak ","Supreme Crt-Justice Bolger ","","NP ","YES ",49
@@ -22474,8 +22474,8 @@
 "38","38-828 Kwethluk ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-828 Kwethluk ","State House","38","DEM ","Fansler, Zach ",130
 "38","38-828 Kwethluk ","State House","38","NP ","Write-in 20 ",3
-"38","38-828 Kwethluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"38","38-828 Kwethluk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",82
+"38","38-828 Kwethluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"38","38-828 Kwethluk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",82
 "38","38-828 Kwethluk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",77
 "38","38-828 Kwethluk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",68
 "38","38-828 Kwethluk ","Supreme Crt-Justice Bolger ","","NP ","YES ",86
@@ -22521,8 +22521,8 @@
 "38","38-830 Kwigillingok ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-830 Kwigillingok ","State House","38","DEM ","Fansler, Zach ",73
 "38","38-830 Kwigillingok ","State House","38","NP ","Write-in 20 ",2
-"38","38-830 Kwigillingok ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",40
-"38","38-830 Kwigillingok ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",42
+"38","38-830 Kwigillingok ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",40
+"38","38-830 Kwigillingok ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",42
 "38","38-830 Kwigillingok ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",40
 "38","38-830 Kwigillingok ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",41
 "38","38-830 Kwigillingok ","Supreme Crt-Justice Bolger ","","NP ","YES ",56
@@ -22568,8 +22568,8 @@
 "38","38-832 Lower Kalskag ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-832 Lower Kalskag ","State House","38","DEM ","Fansler, Zach ",69
 "38","38-832 Lower Kalskag ","State House","38","NP ","Write-in 20 ",0
-"38","38-832 Lower Kalskag ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",58
-"38","38-832 Lower Kalskag ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",18
+"38","38-832 Lower Kalskag ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",58
+"38","38-832 Lower Kalskag ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",18
 "38","38-832 Lower Kalskag ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",55
 "38","38-832 Lower Kalskag ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",19
 "38","38-832 Lower Kalskag ","Supreme Crt-Justice Bolger ","","NP ","YES ",31
@@ -22615,8 +22615,8 @@
 "38","38-834 Marshall ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-834 Marshall ","State House","38","DEM ","Fansler, Zach ",82
 "38","38-834 Marshall ","State House","38","NP ","Write-in 20 ",2
-"38","38-834 Marshall ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",75
-"38","38-834 Marshall ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",25
+"38","38-834 Marshall ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",75
+"38","38-834 Marshall ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",25
 "38","38-834 Marshall ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",55
 "38","38-834 Marshall ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",45
 "38","38-834 Marshall ","Supreme Crt-Justice Bolger ","","NP ","YES ",63
@@ -22662,8 +22662,8 @@
 "38","38-836 Mekoryuk ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-836 Mekoryuk ","State House","38","DEM ","Fansler, Zach ",64
 "38","38-836 Mekoryuk ","State House","38","NP ","Write-in 20 ",8
-"38","38-836 Mekoryuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",56
-"38","38-836 Mekoryuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"38","38-836 Mekoryuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",56
+"38","38-836 Mekoryuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "38","38-836 Mekoryuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",43
 "38","38-836 Mekoryuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",39
 "38","38-836 Mekoryuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",49
@@ -22709,8 +22709,8 @@
 "38","38-838 Napakiak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-838 Napakiak ","State House","38","DEM ","Fansler, Zach ",86
 "38","38-838 Napakiak ","State House","38","NP ","Write-in 20 ",0
-"38","38-838 Napakiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",77
-"38","38-838 Napakiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",19
+"38","38-838 Napakiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",77
+"38","38-838 Napakiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",19
 "38","38-838 Napakiak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",66
 "38","38-838 Napakiak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",30
 "38","38-838 Napakiak ","Supreme Crt-Justice Bolger ","","NP ","YES ",61
@@ -22756,8 +22756,8 @@
 "38","38-840 Napaskiak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-840 Napaskiak ","State House","38","DEM ","Fansler, Zach ",81
 "38","38-840 Napaskiak ","State House","38","NP ","Write-in 20 ",0
-"38","38-840 Napaskiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"38","38-840 Napaskiak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",24
+"38","38-840 Napaskiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"38","38-840 Napaskiak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",24
 "38","38-840 Napaskiak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",61
 "38","38-840 Napaskiak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",31
 "38","38-840 Napaskiak ","Supreme Crt-Justice Bolger ","","NP ","YES ",59
@@ -22803,8 +22803,8 @@
 "38","38-842 Newtok ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-842 Newtok ","State House","38","DEM ","Fansler, Zach ",105
 "38","38-842 Newtok ","State House","38","NP ","Write-in 20 ",0
-"38","38-842 Newtok ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"38","38-842 Newtok ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",51
+"38","38-842 Newtok ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"38","38-842 Newtok ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",51
 "38","38-842 Newtok ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",59
 "38","38-842 Newtok ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",57
 "38","38-842 Newtok ","Supreme Crt-Justice Bolger ","","NP ","YES ",61
@@ -22850,8 +22850,8 @@
 "38","38-844 Nightmute ","U.S. House","1","NP ","Write-in 50 ",1
 "38","38-844 Nightmute ","State House","38","DEM ","Fansler, Zach ",69
 "38","38-844 Nightmute ","State House","38","NP ","Write-in 20 ",1
-"38","38-844 Nightmute ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",50
-"38","38-844 Nightmute ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",28
+"38","38-844 Nightmute ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",50
+"38","38-844 Nightmute ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",28
 "38","38-844 Nightmute ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",46
 "38","38-844 Nightmute ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",31
 "38","38-844 Nightmute ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -22897,8 +22897,8 @@
 "38","38-846 Nunapitchuk ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-846 Nunapitchuk ","State House","38","DEM ","Fansler, Zach ",93
 "38","38-846 Nunapitchuk ","State House","38","NP ","Write-in 20 ",1
-"38","38-846 Nunapitchuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",66
-"38","38-846 Nunapitchuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",35
+"38","38-846 Nunapitchuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",66
+"38","38-846 Nunapitchuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",35
 "38","38-846 Nunapitchuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",55
 "38","38-846 Nunapitchuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",44
 "38","38-846 Nunapitchuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",60
@@ -22944,8 +22944,8 @@
 "38","38-848 Quinhagak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-848 Quinhagak ","State House","38","DEM ","Fansler, Zach ",122
 "38","38-848 Quinhagak ","State House","38","NP ","Write-in 20 ",8
-"38","38-848 Quinhagak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",88
-"38","38-848 Quinhagak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",49
+"38","38-848 Quinhagak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",88
+"38","38-848 Quinhagak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",49
 "38","38-848 Quinhagak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",68
 "38","38-848 Quinhagak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",70
 "38","38-848 Quinhagak ","Supreme Crt-Justice Bolger ","","NP ","YES ",81
@@ -22991,8 +22991,8 @@
 "38","38-850 Russian Mission ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-850 Russian Mission ","State House","38","DEM ","Fansler, Zach ",81
 "38","38-850 Russian Mission ","State House","38","NP ","Write-in 20 ",2
-"38","38-850 Russian Mission ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",64
-"38","38-850 Russian Mission ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",35
+"38","38-850 Russian Mission ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",64
+"38","38-850 Russian Mission ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",35
 "38","38-850 Russian Mission ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",42
 "38","38-850 Russian Mission ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",55
 "38","38-850 Russian Mission ","Supreme Crt-Justice Bolger ","","NP ","YES ",62
@@ -23038,8 +23038,8 @@
 "38","38-852 Toksook Bay ","U.S. House","1","NP ","Write-in 50 ",2
 "38","38-852 Toksook Bay ","State House","38","DEM ","Fansler, Zach ",201
 "38","38-852 Toksook Bay ","State House","38","NP ","Write-in 20 ",2
-"38","38-852 Toksook Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",149
-"38","38-852 Toksook Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",67
+"38","38-852 Toksook Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",149
+"38","38-852 Toksook Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",67
 "38","38-852 Toksook Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",105
 "38","38-852 Toksook Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",109
 "38","38-852 Toksook Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",115
@@ -23085,8 +23085,8 @@
 "38","38-854 Tuluksak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-854 Tuluksak ","State House","38","DEM ","Fansler, Zach ",84
 "38","38-854 Tuluksak ","State House","38","NP ","Write-in 20 ",0
-"38","38-854 Tuluksak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",62
-"38","38-854 Tuluksak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",24
+"38","38-854 Tuluksak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",62
+"38","38-854 Tuluksak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",24
 "38","38-854 Tuluksak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",47
 "38","38-854 Tuluksak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",39
 "38","38-854 Tuluksak ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -23132,8 +23132,8 @@
 "38","38-856 Tuntutuliak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-856 Tuntutuliak ","State House","38","DEM ","Fansler, Zach ",87
 "38","38-856 Tuntutuliak ","State House","38","NP ","Write-in 20 ",0
-"38","38-856 Tuntutuliak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",61
-"38","38-856 Tuntutuliak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",41
+"38","38-856 Tuntutuliak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",61
+"38","38-856 Tuntutuliak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",41
 "38","38-856 Tuntutuliak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",48
 "38","38-856 Tuntutuliak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",50
 "38","38-856 Tuntutuliak ","Supreme Crt-Justice Bolger ","","NP ","YES ",61
@@ -23179,8 +23179,8 @@
 "38","38-858 Tununak ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-858 Tununak ","State House","38","DEM ","Fansler, Zach ",100
 "38","38-858 Tununak ","State House","38","NP ","Write-in 20 ",0
-"38","38-858 Tununak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",60
-"38","38-858 Tununak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",53
+"38","38-858 Tununak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",60
+"38","38-858 Tununak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",53
 "38","38-858 Tununak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",57
 "38","38-858 Tununak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",60
 "38","38-858 Tununak ","Supreme Crt-Justice Bolger ","","NP ","YES ",64
@@ -23226,8 +23226,8 @@
 "38","38-860 Upper Kalskag ","U.S. House","1","NP ","Write-in 50 ",0
 "38","38-860 Upper Kalskag ","State House","38","DEM ","Fansler, Zach ",46
 "38","38-860 Upper Kalskag ","State House","38","NP ","Write-in 20 ",1
-"38","38-860 Upper Kalskag ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",38
-"38","38-860 Upper Kalskag ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",19
+"38","38-860 Upper Kalskag ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",38
+"38","38-860 Upper Kalskag ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",19
 "38","38-860 Upper Kalskag ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",25
 "38","38-860 Upper Kalskag ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",30
 "38","38-860 Upper Kalskag ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -23275,8 +23275,8 @@
 "39","39-314 Galena ","State Senate","T","NP ","Write-in 20 ",6
 "39","39-314 Galena ","State House","39","DEM ","Foster, Neal W.  ",156
 "39","39-314 Galena ","State House","39","NP ","Write-in 20 ",4
-"39","39-314 Galena ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",144
-"39","39-314 Galena ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",45
+"39","39-314 Galena ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",144
+"39","39-314 Galena ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",45
 "39","39-314 Galena ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",105
 "39","39-314 Galena ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",75
 "39","39-314 Galena ","Supreme Crt-Justice Bolger ","","NP ","YES ",113
@@ -23324,8 +23324,8 @@
 "39","39-316 Huslia ","State Senate","T","NP ","Write-in 20 ",4
 "39","39-316 Huslia ","State House","39","DEM ","Foster, Neal W.  ",87
 "39","39-316 Huslia ","State House","39","NP ","Write-in 20 ",3
-"39","39-316 Huslia ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",78
-"39","39-316 Huslia ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",26
+"39","39-316 Huslia ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",78
+"39","39-316 Huslia ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",26
 "39","39-316 Huslia ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",58
 "39","39-316 Huslia ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "39","39-316 Huslia ","Supreme Crt-Justice Bolger ","","NP ","YES ",49
@@ -23373,8 +23373,8 @@
 "39","39-318 Kaltag ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-318 Kaltag ","State House","39","DEM ","Foster, Neal W.  ",45
 "39","39-318 Kaltag ","State House","39","NP ","Write-in 20 ",0
-"39","39-318 Kaltag ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",38
-"39","39-318 Kaltag ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"39","39-318 Kaltag ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",38
+"39","39-318 Kaltag ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "39","39-318 Kaltag ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",32
 "39","39-318 Kaltag ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",16
 "39","39-318 Kaltag ","Supreme Crt-Justice Bolger ","","NP ","YES ",30
@@ -23422,8 +23422,8 @@
 "39","39-320 Koyukuk ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-320 Koyukuk ","State House","39","DEM ","Foster, Neal W.  ",35
 "39","39-320 Koyukuk ","State House","39","NP ","Write-in 20 ",0
-"39","39-320 Koyukuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",26
-"39","39-320 Koyukuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",14
+"39","39-320 Koyukuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",26
+"39","39-320 Koyukuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",14
 "39","39-320 Koyukuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",21
 "39","39-320 Koyukuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",21
 "39","39-320 Koyukuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",16
@@ -23471,8 +23471,8 @@
 "39","39-322 Nulato ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-322 Nulato ","State House","39","DEM ","Foster, Neal W.  ",74
 "39","39-322 Nulato ","State House","39","NP ","Write-in 20 ",0
-"39","39-322 Nulato ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",68
-"39","39-322 Nulato ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",15
+"39","39-322 Nulato ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",68
+"39","39-322 Nulato ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",15
 "39","39-322 Nulato ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",57
 "39","39-322 Nulato ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "39","39-322 Nulato ","Supreme Crt-Justice Bolger ","","NP ","YES ",51
@@ -23520,8 +23520,8 @@
 "39","39-324 Ruby ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-324 Ruby ","State House","39","DEM ","Foster, Neal W.  ",39
 "39","39-324 Ruby ","State House","39","NP ","Write-in 20 ",0
-"39","39-324 Ruby ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",36
-"39","39-324 Ruby ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"39","39-324 Ruby ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",36
+"39","39-324 Ruby ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "39","39-324 Ruby ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",28
 "39","39-324 Ruby ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",18
 "39","39-324 Ruby ","Supreme Crt-Justice Bolger ","","NP ","YES ",19
@@ -23569,8 +23569,8 @@
 "39","39-900 Alakanuk ","State Senate","T","NP ","Write-in 20 ",3
 "39","39-900 Alakanuk ","State House","39","DEM ","Foster, Neal W.  ",103
 "39","39-900 Alakanuk ","State House","39","NP ","Write-in 20 ",2
-"39","39-900 Alakanuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",87
-"39","39-900 Alakanuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",33
+"39","39-900 Alakanuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",87
+"39","39-900 Alakanuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",33
 "39","39-900 Alakanuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",62
 "39","39-900 Alakanuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",59
 "39","39-900 Alakanuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",80
@@ -23618,8 +23618,8 @@
 "39","39-902 Brevig Mission ","State Senate","T","NP ","Write-in 20 ",4
 "39","39-902 Brevig Mission ","State House","39","DEM ","Foster, Neal W.  ",108
 "39","39-902 Brevig Mission ","State House","39","NP ","Write-in 20 ",2
-"39","39-902 Brevig Mission ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",87
-"39","39-902 Brevig Mission ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",32
+"39","39-902 Brevig Mission ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",87
+"39","39-902 Brevig Mission ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",32
 "39","39-902 Brevig Mission ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",62
 "39","39-902 Brevig Mission ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",57
 "39","39-902 Brevig Mission ","Supreme Crt-Justice Bolger ","","NP ","YES ",82
@@ -23651,8 +23651,8 @@
 "39","39-904 Chevak ","State Senate","T","NP ","Write-in 20 ",1
 "39","39-904 Chevak ","State House","39","DEM ","Foster, Neal W.  ",170
 "39","39-904 Chevak ","State House","39","NP ","Write-in 20 ",0
-"39","39-904 Chevak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",118
-"39","39-904 Chevak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",71
+"39","39-904 Chevak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",118
+"39","39-904 Chevak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",71
 "39","39-904 Chevak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "39","39-904 Chevak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",65
 "39","39-904 Chevak ","Supreme Crt-Justice Bolger ","","NP ","YES ",112
@@ -23700,8 +23700,8 @@
 "39","39-906 Diomede ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-906 Diomede ","State House","39","DEM ","Foster, Neal W.  ",7
 "39","39-906 Diomede ","State House","39","NP ","Write-in 20 ",0
-"39","39-906 Diomede ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",9
-"39","39-906 Diomede ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",2
+"39","39-906 Diomede ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",9
+"39","39-906 Diomede ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",2
 "39","39-906 Diomede ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",7
 "39","39-906 Diomede ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",4
 "39","39-906 Diomede ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -23733,8 +23733,8 @@
 "39","39-908 Elim ","State Senate","T","NP ","Write-in 20 ",1
 "39","39-908 Elim ","State House","39","DEM ","Foster, Neal W.  ",91
 "39","39-908 Elim ","State House","39","NP ","Write-in 20 ",0
-"39","39-908 Elim ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",79
-"39","39-908 Elim ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",22
+"39","39-908 Elim ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",79
+"39","39-908 Elim ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",22
 "39","39-908 Elim ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",62
 "39","39-908 Elim ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",38
 "39","39-908 Elim ","Supreme Crt-Justice Bolger ","","NP ","YES ",67
@@ -23766,8 +23766,8 @@
 "39","39-910 Emmonak ","State Senate","T","NP ","Write-in 20 ",4
 "39","39-910 Emmonak ","State House","39","DEM ","Foster, Neal W.  ",158
 "39","39-910 Emmonak ","State House","39","NP ","Write-in 20 ",3
-"39","39-910 Emmonak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",123
-"39","39-910 Emmonak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",54
+"39","39-910 Emmonak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",123
+"39","39-910 Emmonak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",54
 "39","39-910 Emmonak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",95
 "39","39-910 Emmonak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",81
 "39","39-910 Emmonak ","Supreme Crt-Justice Bolger ","","NP ","YES ",91
@@ -23815,8 +23815,8 @@
 "39","39-912 Gambell ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-912 Gambell ","State House","39","DEM ","Foster, Neal W.  ",148
 "39","39-912 Gambell ","State House","39","NP ","Write-in 20 ",1
-"39","39-912 Gambell ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",122
-"39","39-912 Gambell ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",49
+"39","39-912 Gambell ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",122
+"39","39-912 Gambell ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",49
 "39","39-912 Gambell ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",92
 "39","39-912 Gambell ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",81
 "39","39-912 Gambell ","Supreme Crt-Justice Bolger ","","NP ","YES ",118
@@ -23848,8 +23848,8 @@
 "39","39-914 Golovin ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-914 Golovin ","State House","39","DEM ","Foster, Neal W.  ",52
 "39","39-914 Golovin ","State House","39","NP ","Write-in 20 ",2
-"39","39-914 Golovin ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",34
-"39","39-914 Golovin ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"39","39-914 Golovin ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",34
+"39","39-914 Golovin ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "39","39-914 Golovin ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",28
 "39","39-914 Golovin ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "39","39-914 Golovin ","Supreme Crt-Justice Bolger ","","NP ","YES ",39
@@ -23881,8 +23881,8 @@
 "39","39-916 Hooper Bay ","State Senate","T","NP ","Write-in 20 ",3
 "39","39-916 Hooper Bay ","State House","39","DEM ","Foster, Neal W.  ",190
 "39","39-916 Hooper Bay ","State House","39","NP ","Write-in 20 ",3
-"39","39-916 Hooper Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",147
-"39","39-916 Hooper Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",71
+"39","39-916 Hooper Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",147
+"39","39-916 Hooper Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",71
 "39","39-916 Hooper Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",123
 "39","39-916 Hooper Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",98
 "39","39-916 Hooper Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",134
@@ -23930,8 +23930,8 @@
 "39","39-918 Kotlik ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-918 Kotlik ","State House","39","DEM ","Foster, Neal W.  ",91
 "39","39-918 Kotlik ","State House","39","NP ","Write-in 20 ",0
-"39","39-918 Kotlik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",65
-"39","39-918 Kotlik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",36
+"39","39-918 Kotlik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",65
+"39","39-918 Kotlik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",36
 "39","39-918 Kotlik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",50
 "39","39-918 Kotlik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",50
 "39","39-918 Kotlik ","Supreme Crt-Justice Bolger ","","NP ","YES ",78
@@ -23979,8 +23979,8 @@
 "39","39-920 Koyuk ","State Senate","T","NP ","Write-in 20 ",1
 "39","39-920 Koyuk ","State House","39","DEM ","Foster, Neal W.  ",83
 "39","39-920 Koyuk ","State House","39","NP ","Write-in 20 ",3
-"39","39-920 Koyuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",63
-"39","39-920 Koyuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",26
+"39","39-920 Koyuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",63
+"39","39-920 Koyuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",26
 "39","39-920 Koyuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",45
 "39","39-920 Koyuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "39","39-920 Koyuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",67
@@ -24012,8 +24012,8 @@
 "39","39-922 Mountain Village ","State Senate","T","NP ","Write-in 20 ",4
 "39","39-922 Mountain Village ","State House","39","DEM ","Foster, Neal W.  ",141
 "39","39-922 Mountain Village ","State House","39","NP ","Write-in 20 ",6
-"39","39-922 Mountain Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",106
-"39","39-922 Mountain Village ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",58
+"39","39-922 Mountain Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",106
+"39","39-922 Mountain Village ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",58
 "39","39-922 Mountain Village ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",98
 "39","39-922 Mountain Village ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",64
 "39","39-922 Mountain Village ","Supreme Crt-Justice Bolger ","","NP ","YES ",103
@@ -24061,8 +24061,8 @@
 "39","39-924 Nome No. 1 ","State Senate","T","NP ","Write-in 20 ",21
 "39","39-924 Nome No. 1 ","State House","39","DEM ","Foster, Neal W.  ",340
 "39","39-924 Nome No. 1 ","State House","39","NP ","Write-in 20 ",18
-"39","39-924 Nome No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",291
-"39","39-924 Nome No. 1 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",108
+"39","39-924 Nome No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",291
+"39","39-924 Nome No. 1 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",108
 "39","39-924 Nome No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",190
 "39","39-924 Nome No. 1 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",195
 "39","39-924 Nome No. 1 ","Supreme Crt-Justice Bolger ","","NP ","YES ",232
@@ -24094,8 +24094,8 @@
 "39","39-926 Nome No. 2 ","State Senate","T","NP ","Write-in 20 ",42
 "39","39-926 Nome No. 2 ","State House","39","DEM ","Foster, Neal W.  ",458
 "39","39-926 Nome No. 2 ","State House","39","NP ","Write-in 20 ",40
-"39","39-926 Nome No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",404
-"39","39-926 Nome No. 2 ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",141
+"39","39-926 Nome No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",404
+"39","39-926 Nome No. 2 ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",141
 "39","39-926 Nome No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",287
 "39","39-926 Nome No. 2 ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",250
 "39","39-926 Nome No. 2 ","Supreme Crt-Justice Bolger ","","NP ","YES ",350
@@ -24127,8 +24127,8 @@
 "39","39-928 Nunam Iqua ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-928 Nunam Iqua ","State House","39","DEM ","Foster, Neal W.  ",31
 "39","39-928 Nunam Iqua ","State House","39","NP ","Write-in 20 ",1
-"39","39-928 Nunam Iqua ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",22
-"39","39-928 Nunam Iqua ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"39","39-928 Nunam Iqua ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",22
+"39","39-928 Nunam Iqua ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "39","39-928 Nunam Iqua ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",16
 "39","39-928 Nunam Iqua ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",16
 "39","39-928 Nunam Iqua ","Supreme Crt-Justice Bolger ","","NP ","YES ",23
@@ -24176,8 +24176,8 @@
 "39","39-930 Pilot Station ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-930 Pilot Station ","State House","39","DEM ","Foster, Neal W.  ",132
 "39","39-930 Pilot Station ","State House","39","NP ","Write-in 20 ",1
-"39","39-930 Pilot Station ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",93
-"39","39-930 Pilot Station ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",52
+"39","39-930 Pilot Station ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",93
+"39","39-930 Pilot Station ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",52
 "39","39-930 Pilot Station ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",65
 "39","39-930 Pilot Station ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",81
 "39","39-930 Pilot Station ","Supreme Crt-Justice Bolger ","","NP ","YES ",84
@@ -24225,8 +24225,8 @@
 "39","39-932 Savoonga ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-932 Savoonga ","State House","39","DEM ","Foster, Neal W.  ",213
 "39","39-932 Savoonga ","State House","39","NP ","Write-in 20 ",2
-"39","39-932 Savoonga ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",169
-"39","39-932 Savoonga ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",61
+"39","39-932 Savoonga ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",169
+"39","39-932 Savoonga ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",61
 "39","39-932 Savoonga ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "39","39-932 Savoonga ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",100
 "39","39-932 Savoonga ","Supreme Crt-Justice Bolger ","","NP ","YES ",157
@@ -24258,8 +24258,8 @@
 "39","39-934 Scammon Bay ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-934 Scammon Bay ","State House","39","DEM ","Foster, Neal W.  ",131
 "39","39-934 Scammon Bay ","State House","39","NP ","Write-in 20 ",0
-"39","39-934 Scammon Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",107
-"39","39-934 Scammon Bay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",37
+"39","39-934 Scammon Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",107
+"39","39-934 Scammon Bay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",37
 "39","39-934 Scammon Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",76
 "39","39-934 Scammon Bay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",65
 "39","39-934 Scammon Bay ","Supreme Crt-Justice Bolger ","","NP ","YES ",93
@@ -24307,8 +24307,8 @@
 "39","39-936 Shaktoolik ","State Senate","T","NP ","Write-in 20 ",2
 "39","39-936 Shaktoolik ","State House","39","DEM ","Foster, Neal W.  ",85
 "39","39-936 Shaktoolik ","State House","39","NP ","Write-in 20 ",0
-"39","39-936 Shaktoolik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",70
-"39","39-936 Shaktoolik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",19
+"39","39-936 Shaktoolik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",70
+"39","39-936 Shaktoolik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",19
 "39","39-936 Shaktoolik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",52
 "39","39-936 Shaktoolik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",37
 "39","39-936 Shaktoolik ","Supreme Crt-Justice Bolger ","","NP ","YES ",69
@@ -24340,8 +24340,8 @@
 "39","39-938 Shishmaref ","State Senate","T","NP ","Write-in 20 ",3
 "39","39-938 Shishmaref ","State House","39","DEM ","Foster, Neal W.  ",180
 "39","39-938 Shishmaref ","State House","39","NP ","Write-in 20 ",3
-"39","39-938 Shishmaref ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",135
-"39","39-938 Shishmaref ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",60
+"39","39-938 Shishmaref ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",135
+"39","39-938 Shishmaref ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",60
 "39","39-938 Shishmaref ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",100
 "39","39-938 Shishmaref ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",93
 "39","39-938 Shishmaref ","Supreme Crt-Justice Bolger ","","NP ","YES ",142
@@ -24373,8 +24373,8 @@
 "39","39-940 St. Mary's ","State Senate","T","NP ","Write-in 20 ",4
 "39","39-940 St. Mary's ","State House","39","DEM ","Foster, Neal W.  ",140
 "39","39-940 St. Mary's ","State House","39","NP ","Write-in 20 ",6
-"39","39-940 St. Mary's ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",118
-"39","39-940 St. Mary's ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",42
+"39","39-940 St. Mary's ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",118
+"39","39-940 St. Mary's ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",42
 "39","39-940 St. Mary's ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",97
 "39","39-940 St. Mary's ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",63
 "39","39-940 St. Mary's ","Supreme Crt-Justice Bolger ","","NP ","YES ",102
@@ -24422,8 +24422,8 @@
 "39","39-942 St. Michael ","State Senate","T","NP ","Write-in 20 ",2
 "39","39-942 St. Michael ","State House","39","DEM ","Foster, Neal W.  ",73
 "39","39-942 St. Michael ","State House","39","NP ","Write-in 20 ",1
-"39","39-942 St. Michael ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",62
-"39","39-942 St. Michael ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",17
+"39","39-942 St. Michael ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",62
+"39","39-942 St. Michael ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",17
 "39","39-942 St. Michael ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",45
 "39","39-942 St. Michael ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",33
 "39","39-942 St. Michael ","Supreme Crt-Justice Bolger ","","NP ","YES ",57
@@ -24455,8 +24455,8 @@
 "39","39-944 Stebbins ","State Senate","T","NP ","Write-in 20 ",1
 "39","39-944 Stebbins ","State House","39","DEM ","Foster, Neal W.  ",99
 "39","39-944 Stebbins ","State House","39","NP ","Write-in 20 ",1
-"39","39-944 Stebbins ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",74
-"39","39-944 Stebbins ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",38
+"39","39-944 Stebbins ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",74
+"39","39-944 Stebbins ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",38
 "39","39-944 Stebbins ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",64
 "39","39-944 Stebbins ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",45
 "39","39-944 Stebbins ","Supreme Crt-Justice Bolger ","","NP ","YES ",68
@@ -24488,8 +24488,8 @@
 "39","39-946 Teller ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-946 Teller ","State House","39","DEM ","Foster, Neal W.  ",61
 "39","39-946 Teller ","State House","39","NP ","Write-in 20 ",2
-"39","39-946 Teller ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",47
-"39","39-946 Teller ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"39","39-946 Teller ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",47
+"39","39-946 Teller ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "39","39-946 Teller ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",44
 "39","39-946 Teller ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",25
 "39","39-946 Teller ","Supreme Crt-Justice Bolger ","","NP ","YES ",50
@@ -24521,8 +24521,8 @@
 "39","39-948 Unalakleet ","State Senate","T","NP ","Write-in 20 ",12
 "39","39-948 Unalakleet ","State House","39","DEM ","Foster, Neal W.  ",228
 "39","39-948 Unalakleet ","State House","39","NP ","Write-in 20 ",6
-"39","39-948 Unalakleet ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",202
-"39","39-948 Unalakleet ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",56
+"39","39-948 Unalakleet ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",202
+"39","39-948 Unalakleet ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",56
 "39","39-948 Unalakleet ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",161
 "39","39-948 Unalakleet ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",88
 "39","39-948 Unalakleet ","Supreme Crt-Justice Bolger ","","NP ","YES ",176
@@ -24554,8 +24554,8 @@
 "39","39-950 Wales ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-950 Wales ","State House","39","DEM ","Foster, Neal W.  ",34
 "39","39-950 Wales ","State House","39","NP ","Write-in 20 ",2
-"39","39-950 Wales ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",34
-"39","39-950 Wales ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",9
+"39","39-950 Wales ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",34
+"39","39-950 Wales ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",9
 "39","39-950 Wales ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",25
 "39","39-950 Wales ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",18
 "39","39-950 Wales ","Supreme Crt-Justice Bolger ","","NP ","YES ",28
@@ -24587,8 +24587,8 @@
 "39","39-952 White Mountain ","State Senate","T","NP ","Write-in 20 ",0
 "39","39-952 White Mountain ","State House","39","DEM ","Foster, Neal W.  ",58
 "39","39-952 White Mountain ","State House","39","NP ","Write-in 20 ",2
-"39","39-952 White Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",51
-"39","39-952 White Mountain ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",13
+"39","39-952 White Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",51
+"39","39-952 White Mountain ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",13
 "39","39-952 White Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",31
 "39","39-952 White Mountain ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",34
 "39","39-952 White Mountain ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -24620,8 +24620,8 @@
 "40","40-002 Ambler ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-002 Ambler ","State House","40","DEM ","Westlake, Dean ",68
 "40","40-002 Ambler ","State House","40","NP ","Write-in 30 ",3
-"40","40-002 Ambler ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",53
-"40","40-002 Ambler ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"40","40-002 Ambler ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",53
+"40","40-002 Ambler ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "40","40-002 Ambler ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",43
 "40","40-002 Ambler ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",34
 "40","40-002 Ambler ","Supreme Crt-Justice Bolger ","","NP ","YES ",47
@@ -24653,8 +24653,8 @@
 "40","40-004 Anaktuvuk Pass ","State Senate","T","NP ","Write-in 20 ",2
 "40","40-004 Anaktuvuk Pass ","State House","40","DEM ","Westlake, Dean ",63
 "40","40-004 Anaktuvuk Pass ","State House","40","NP ","Write-in 30 ",29
-"40","40-004 Anaktuvuk Pass ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",69
-"40","40-004 Anaktuvuk Pass ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",32
+"40","40-004 Anaktuvuk Pass ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",69
+"40","40-004 Anaktuvuk Pass ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",32
 "40","40-004 Anaktuvuk Pass ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",52
 "40","40-004 Anaktuvuk Pass ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",49
 "40","40-004 Anaktuvuk Pass ","Supreme Crt-Justice Bolger ","","NP ","YES ",66
@@ -24686,8 +24686,8 @@
 "40","40-006 Atqasuk ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-006 Atqasuk ","State House","40","DEM ","Westlake, Dean ",35
 "40","40-006 Atqasuk ","State House","40","NP ","Write-in 30 ",20
-"40","40-006 Atqasuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",41
-"40","40-006 Atqasuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",23
+"40","40-006 Atqasuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",41
+"40","40-006 Atqasuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",23
 "40","40-006 Atqasuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",34
 "40","40-006 Atqasuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",29
 "40","40-006 Atqasuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",32
@@ -24719,8 +24719,8 @@
 "40","40-008 Barrow ","State Senate","T","NP ","Write-in 20 ",12
 "40","40-008 Barrow ","State House","40","DEM ","Westlake, Dean ",174
 "40","40-008 Barrow ","State House","40","NP ","Write-in 30 ",92
-"40","40-008 Barrow ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",244
-"40","40-008 Barrow ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",77
+"40","40-008 Barrow ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",244
+"40","40-008 Barrow ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",77
 "40","40-008 Barrow ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",185
 "40","40-008 Barrow ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",133
 "40","40-008 Barrow ","Supreme Crt-Justice Bolger ","","NP ","YES ",214
@@ -24752,8 +24752,8 @@
 "40","40-010 Browerville ","State Senate","T","NP ","Write-in 20 ",35
 "40","40-010 Browerville ","State House","40","DEM ","Westlake, Dean ",405
 "40","40-010 Browerville ","State House","40","NP ","Write-in 30 ",287
-"40","40-010 Browerville ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",604
-"40","40-010 Browerville ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",182
+"40","40-010 Browerville ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",604
+"40","40-010 Browerville ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",182
 "40","40-010 Browerville ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",427
 "40","40-010 Browerville ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",355
 "40","40-010 Browerville ","Supreme Crt-Justice Bolger ","","NP ","YES ",487
@@ -24785,8 +24785,8 @@
 "40","40-012 Buckland ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-012 Buckland ","State House","40","DEM ","Westlake, Dean ",116
 "40","40-012 Buckland ","State House","40","NP ","Write-in 30 ",2
-"40","40-012 Buckland ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",75
-"40","40-012 Buckland ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",47
+"40","40-012 Buckland ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",75
+"40","40-012 Buckland ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",47
 "40","40-012 Buckland ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",48
 "40","40-012 Buckland ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",72
 "40","40-012 Buckland ","Supreme Crt-Justice Bolger ","","NP ","YES ",80
@@ -24818,8 +24818,8 @@
 "40","40-014 Deering ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-014 Deering ","State House","40","DEM ","Westlake, Dean ",39
 "40","40-014 Deering ","State House","40","NP ","Write-in 30 ",1
-"40","40-014 Deering ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",20
-"40","40-014 Deering ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"40","40-014 Deering ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",20
+"40","40-014 Deering ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "40","40-014 Deering ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",21
 "40","40-014 Deering ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",25
 "40","40-014 Deering ","Supreme Crt-Justice Bolger ","","NP ","YES ",27
@@ -24851,8 +24851,8 @@
 "40","40-016 Kaktovik ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-016 Kaktovik ","State House","40","DEM ","Westlake, Dean ",45
 "40","40-016 Kaktovik ","State House","40","NP ","Write-in 30 ",21
-"40","40-016 Kaktovik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",54
-"40","40-016 Kaktovik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",21
+"40","40-016 Kaktovik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",54
+"40","40-016 Kaktovik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",21
 "40","40-016 Kaktovik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",32
 "40","40-016 Kaktovik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "40","40-016 Kaktovik ","Supreme Crt-Justice Bolger ","","NP ","YES ",41
@@ -24884,8 +24884,8 @@
 "40","40-018 Kiana ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-018 Kiana ","State House","40","DEM ","Westlake, Dean ",90
 "40","40-018 Kiana ","State House","40","NP ","Write-in 30 ",12
-"40","40-018 Kiana ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",67
-"40","40-018 Kiana ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",40
+"40","40-018 Kiana ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",67
+"40","40-018 Kiana ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",40
 "40","40-018 Kiana ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",66
 "40","40-018 Kiana ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "40","40-018 Kiana ","Supreme Crt-Justice Bolger ","","NP ","YES ",65
@@ -24917,8 +24917,8 @@
 "40","40-020 Kivalina ","State Senate","T","NP ","Write-in 20 ",2
 "40","40-020 Kivalina ","State House","40","DEM ","Westlake, Dean ",104
 "40","40-020 Kivalina ","State House","40","NP ","Write-in 30 ",10
-"40","40-020 Kivalina ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",69
-"40","40-020 Kivalina ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",46
+"40","40-020 Kivalina ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",69
+"40","40-020 Kivalina ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",46
 "40","40-020 Kivalina ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",63
 "40","40-020 Kivalina ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",52
 "40","40-020 Kivalina ","Supreme Crt-Justice Bolger ","","NP ","YES ",72
@@ -24950,8 +24950,8 @@
 "40","40-022 Kobuk ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-022 Kobuk ","State House","40","DEM ","Westlake, Dean ",38
 "40","40-022 Kobuk ","State House","40","NP ","Write-in 30 ",0
-"40","40-022 Kobuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",30
-"40","40-022 Kobuk ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"40","40-022 Kobuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",30
+"40","40-022 Kobuk ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "40","40-022 Kobuk ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",24
 "40","40-022 Kobuk ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",18
 "40","40-022 Kobuk ","Supreme Crt-Justice Bolger ","","NP ","YES ",22
@@ -24983,8 +24983,8 @@
 "40","40-024 Kotzebue ","State Senate","T","NP ","Write-in 20 ",9
 "40","40-024 Kotzebue ","State House","40","DEM ","Westlake, Dean ",548
 "40","40-024 Kotzebue ","State House","40","NP ","Write-in 30 ",75
-"40","40-024 Kotzebue ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",528
-"40","40-024 Kotzebue ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",177
+"40","40-024 Kotzebue ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",528
+"40","40-024 Kotzebue ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",177
 "40","40-024 Kotzebue ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",370
 "40","40-024 Kotzebue ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",320
 "40","40-024 Kotzebue ","Supreme Crt-Justice Bolger ","","NP ","YES ",432
@@ -25016,8 +25016,8 @@
 "40","40-026 Noatak ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-026 Noatak ","State House","40","DEM ","Westlake, Dean ",125
 "40","40-026 Noatak ","State House","40","NP ","Write-in 30 ",8
-"40","40-026 Noatak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",80
-"40","40-026 Noatak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",62
+"40","40-026 Noatak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",80
+"40","40-026 Noatak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",62
 "40","40-026 Noatak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",64
 "40","40-026 Noatak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",74
 "40","40-026 Noatak ","Supreme Crt-Justice Bolger ","","NP ","YES ",96
@@ -25049,8 +25049,8 @@
 "40","40-028 Noorvik ","State Senate","T","NP ","Write-in 20 ",2
 "40","40-028 Noorvik ","State House","40","DEM ","Westlake, Dean ",129
 "40","40-028 Noorvik ","State House","40","NP ","Write-in 30 ",8
-"40","40-028 Noorvik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",78
-"40","40-028 Noorvik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",67
+"40","40-028 Noorvik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",78
+"40","40-028 Noorvik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",67
 "40","40-028 Noorvik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",68
 "40","40-028 Noorvik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",73
 "40","40-028 Noorvik ","Supreme Crt-Justice Bolger ","","NP ","YES ",81
@@ -25082,8 +25082,8 @@
 "40","40-030 Nuiqsut ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-030 Nuiqsut ","State House","40","DEM ","Westlake, Dean ",72
 "40","40-030 Nuiqsut ","State House","40","NP ","Write-in 30 ",24
-"40","40-030 Nuiqsut ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",72
-"40","40-030 Nuiqsut ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",33
+"40","40-030 Nuiqsut ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",72
+"40","40-030 Nuiqsut ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",33
 "40","40-030 Nuiqsut ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",59
 "40","40-030 Nuiqsut ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",49
 "40","40-030 Nuiqsut ","Supreme Crt-Justice Bolger ","","NP ","YES ",65
@@ -25115,8 +25115,8 @@
 "40","40-032 Point Hope ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-032 Point Hope ","State House","40","DEM ","Westlake, Dean ",117
 "40","40-032 Point Hope ","State House","40","NP ","Write-in 30 ",19
-"40","40-032 Point Hope ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",99
-"40","40-032 Point Hope ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",50
+"40","40-032 Point Hope ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",99
+"40","40-032 Point Hope ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",50
 "40","40-032 Point Hope ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",69
 "40","40-032 Point Hope ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",79
 "40","40-032 Point Hope ","Supreme Crt-Justice Bolger ","","NP ","YES ",91
@@ -25148,8 +25148,8 @@
 "40","40-034 Point Lay ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-034 Point Lay ","State House","40","DEM ","Westlake, Dean ",49
 "40","40-034 Point Lay ","State House","40","NP ","Write-in 30 ",12
-"40","40-034 Point Lay ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",38
-"40","40-034 Point Lay ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"40","40-034 Point Lay ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",38
+"40","40-034 Point Lay ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "40","40-034 Point Lay ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",35
 "40","40-034 Point Lay ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",29
 "40","40-034 Point Lay ","Supreme Crt-Justice Bolger ","","NP ","YES ",40
@@ -25181,8 +25181,8 @@
 "40","40-036 Selawik ","State Senate","T","NP ","Write-in 20 ",2
 "40","40-036 Selawik ","State House","40","DEM ","Westlake, Dean ",105
 "40","40-036 Selawik ","State House","40","NP ","Write-in 30 ",9
-"40","40-036 Selawik ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",70
-"40","40-036 Selawik ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",53
+"40","40-036 Selawik ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",70
+"40","40-036 Selawik ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",53
 "40","40-036 Selawik ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",62
 "40","40-036 Selawik ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",61
 "40","40-036 Selawik ","Supreme Crt-Justice Bolger ","","NP ","YES ",72
@@ -25214,8 +25214,8 @@
 "40","40-038 Shungnak ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-038 Shungnak ","State House","40","DEM ","Westlake, Dean ",81
 "40","40-038 Shungnak ","State House","40","NP ","Write-in 30 ",0
-"40","40-038 Shungnak ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",57
-"40","40-038 Shungnak ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",24
+"40","40-038 Shungnak ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",57
+"40","40-038 Shungnak ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",24
 "40","40-038 Shungnak ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",48
 "40","40-038 Shungnak ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",33
 "40","40-038 Shungnak ","Supreme Crt-Justice Bolger ","","NP ","YES ",52
@@ -25247,8 +25247,8 @@
 "40","40-040 Wainwright ","State Senate","T","NP ","Write-in 20 ",9
 "40","40-040 Wainwright ","State House","40","DEM ","Westlake, Dean ",73
 "40","40-040 Wainwright ","State House","40","NP ","Write-in 30 ",68
-"40","40-040 Wainwright ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",115
-"40","40-040 Wainwright ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",40
+"40","40-040 Wainwright ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",115
+"40","40-040 Wainwright ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",40
 "40","40-040 Wainwright ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",79
 "40","40-040 Wainwright ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",73
 "40","40-040 Wainwright ","Supreme Crt-Justice Bolger ","","NP ","YES ",96
@@ -25280,8 +25280,8 @@
 "40","40-326 Allakaket ","State Senate","T","NP ","Write-in 20 ",1
 "40","40-326 Allakaket ","State House","40","DEM ","Westlake, Dean ",66
 "40","40-326 Allakaket ","State House","40","NP ","Write-in 30 ",1
-"40","40-326 Allakaket ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",54
-"40","40-326 Allakaket ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",19
+"40","40-326 Allakaket ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",54
+"40","40-326 Allakaket ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",19
 "40","40-326 Allakaket ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",51
 "40","40-326 Allakaket ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",24
 "40","40-326 Allakaket ","Supreme Crt-Justice Bolger ","","NP ","YES ",37
@@ -25329,8 +25329,8 @@
 "40","40-328 Bettles ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-328 Bettles ","State House","40","DEM ","Westlake, Dean ",9
 "40","40-328 Bettles ","State House","40","NP ","Write-in 30 ",4
-"40","40-328 Bettles ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",10
-"40","40-328 Bettles ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",5
+"40","40-328 Bettles ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",10
+"40","40-328 Bettles ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",5
 "40","40-328 Bettles ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",8
 "40","40-328 Bettles ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",7
 "40","40-328 Bettles ","Supreme Crt-Justice Bolger ","","NP ","YES ",9
@@ -25378,8 +25378,8 @@
 "40","40-330 Hughes ","State Senate","T","NP ","Write-in 20 ",0
 "40","40-330 Hughes ","State House","40","DEM ","Westlake, Dean ",36
 "40","40-330 Hughes ","State House","40","NP ","Write-in 30 ",0
-"40","40-330 Hughes ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",27
-"40","40-330 Hughes ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",9
+"40","40-330 Hughes ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",27
+"40","40-330 Hughes ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",9
 "40","40-330 Hughes ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",16
 "40","40-330 Hughes ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",21
 "40","40-330 Hughes ","Supreme Crt-Justice Bolger ","","NP ","YES ",21
@@ -25444,8 +25444,8 @@
 "1","District 1 - Absentee ","U.S. House","1","NP ","Write-in 50 ",8
 "1","District 1 - Absentee ","State House","1","DEM ","Kawasaki, Scott J.  ",565
 "1","District 1 - Absentee ","State House","1","NP ","Write-in 20 ",61
-"1","District 1 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",655
-"1","District 1 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",249
+"1","District 1 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",655
+"1","District 1 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",249
 "1","District 1 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",446
 "1","District 1 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",438
 "1","District 1 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",510
@@ -25492,8 +25492,8 @@
 "2","District 2 - Absentee ","State House","2","REP ","Thompson, Steve M.  ",608
 "2","District 2 - Absentee ","State House","2","DEM ","Holdaway, Truno N. L ",213
 "2","District 2 - Absentee ","State House","2","NP ","Write-in 30 ",7
-"2","District 2 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",675
-"2","District 2 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",286
+"2","District 2 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",675
+"2","District 2 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",286
 "2","District 2 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",396
 "2","District 2 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",539
 "2","District 2 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",554
@@ -25544,8 +25544,8 @@
 "3","District 3 - Absentee ","State House","3","REP ","Wilson, Tammie ",626
 "3","District 3 - Absentee ","State House","3","NA ","Olson, Jeanne L.  ",183
 "3","District 3 - Absentee ","State House","3","NP ","Write-in 40 ",3
-"3","District 3 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",701
-"3","District 3 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",312
+"3","District 3 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",701
+"3","District 3 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",312
 "3","District 3 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",379
 "3","District 3 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",616
 "3","District 3 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",578
@@ -25594,8 +25594,8 @@
 "4","District 4 - Absentee ","State Senate","B","NP ","Write-in 30 ",10
 "4","District 4 - Absentee ","State House","4","DEM ","Guttenberg, David ",836
 "4","District 4 - Absentee ","State House","4","NP ","Write-in 20 ",72
-"4","District 4 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",951
-"4","District 4 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",338
+"4","District 4 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",951
+"4","District 4 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",338
 "4","District 4 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",650
 "4","District 4 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",579
 "4","District 4 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",741
@@ -25642,8 +25642,8 @@
 "5","District 5 - Absentee ","State House","5","REP ","Lojewski, Aaron ",512
 "5","District 5 - Absentee ","State House","5","DEM ","Wool, Adam ",518
 "5","District 5 - Absentee ","State House","5","NP ","Write-in 30 ",7
-"5","District 5 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",874
-"5","District 5 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",312
+"5","District 5 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",874
+"5","District 5 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",312
 "5","District 5 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",574
 "5","District 5 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",568
 "5","District 5 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",690
@@ -25690,8 +25690,8 @@
 "6","District 6 - Absentee ","State House","6","REP ","Talerico, David M.  ",1171
 "6","District 6 - Absentee ","State House","6","DEM ","Land, Jason T.  ",531
 "6","District 6 - Absentee ","State House","6","NP ","Write-in 40 ",12
-"6","District 6 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1193
-"6","District 6 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",637
+"6","District 6 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1193
+"6","District 6 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",637
 "6","District 6 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",695
 "6","District 6 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1064
 "6","District 6 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",924
@@ -25776,8 +25776,8 @@
 "7","District 7 - Absentee ","State House","7","REP ","Sullivan-Leonard, Co ",655
 "7","District 7 - Absentee ","State House","7","DEM ","Olson, Sherie A.  ",200
 "7","District 7 - Absentee ","State House","7","NP ","Write-in 30 ",4
-"7","District 7 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",686
-"7","District 7 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",400
+"7","District 7 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",686
+"7","District 7 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",400
 "7","District 7 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",339
 "7","District 7 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",699
 "7","District 7 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",486
@@ -25846,8 +25846,8 @@
 "8","District 8 - Absentee ","State House","8","DEM ","Jones, Gregory I.  ",143
 "8","District 8 - Absentee ","State House","8","REP ","Neuman, Mark A.  ",768
 "8","District 8 - Absentee ","State House","8","NP ","Write-in 30 ",4
-"8","District 8 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",628
-"8","District 8 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",439
+"8","District 8 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",628
+"8","District 8 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",439
 "8","District 8 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",341
 "8","District 8 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",701
 "8","District 8 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",461
@@ -25914,8 +25914,8 @@
 "9","District 9 - Absentee ","State House","9","REP ","Rauscher, George ",1234
 "9","District 9 - Absentee ","State House","9","CON ","Goode, Pamela ",619
 "9","District 9 - Absentee ","State House","9","NP ","Write-in 30 ",83
-"9","District 9 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1382
-"9","District 9 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",803
+"9","District 9 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1382
+"9","District 9 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",803
 "9","District 9 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",770
 "9","District 9 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1348
 "9","District 9 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1062
@@ -25998,8 +25998,8 @@
 "10","District 10 - Absentee ","State House","10","DEM ","Faye-Brazel, Patrici ",447
 "10","District 10 - Absentee ","State House","10","REP ","Eastman, David ",1073
 "10","District 10 - Absentee ","State House","10","NP ","Write-in 30 ",12
-"10","District 10 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1057
-"10","District 10 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",695
+"10","District 10 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1057
+"10","District 10 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",695
 "10","District 10 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",627
 "10","District 10 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1075
 "10","District 10 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",783
@@ -26069,8 +26069,8 @@
 "11","District 11 - Absentee ","State House","11","REP ","Johnson, DeLena ",1272
 "11","District 11 - Absentee ","State House","11","NA ","Verrall, Bert ",630
 "11","District 11 - Absentee ","State House","11","NP ","Write-in 30 ",8
-"11","District 11 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1290
-"11","District 11 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",858
+"11","District 11 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1290
+"11","District 11 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",858
 "11","District 11 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",762
 "11","District 11 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1303
 "11","District 11 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",998
@@ -26141,8 +26141,8 @@
 "12","District 12 - Absentee ","State House","12","CON ","Perry, Karen ",205
 "12","District 12 - Absentee ","State House","12","DEM ","Wehmhoff, Gretchen L ",558
 "12","District 12 - Absentee ","State House","12","NP ","Write-in 40 ",5
-"12","District 12 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1386
-"12","District 12 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",911
+"12","District 12 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1386
+"12","District 12 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",911
 "12","District 12 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",798
 "12","District 12 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1449
 "12","District 12 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1119
@@ -26208,8 +26208,8 @@
 "13","District 13 - Absentee ","U.S. House","1","NP ","Write-in 50 ",6
 "13","District 13 - Absentee ","State House","13","REP ","Saddler, Dan ",929
 "13","District 13 - Absentee ","State House","13","NP ","Write-in 20 ",54
-"13","District 13 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1069
-"13","District 13 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",450
+"13","District 13 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1069
+"13","District 13 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",450
 "13","District 13 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",608
 "13","District 13 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",872
 "13","District 13 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",872
@@ -26276,8 +26276,8 @@
 "14","District 14 - Absentee ","State House","14","NA ","Hackenmueller, Joe ",801
 "14","District 14 - Absentee ","State House","14","REP ","Reinbold, Lora ",1441
 "14","District 14 - Absentee ","State House","14","NP ","Write-in 30 ",12
-"14","District 14 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1499
-"14","District 14 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",935
+"14","District 14 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1499
+"14","District 14 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",935
 "14","District 14 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",890
 "14","District 14 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1473
 "14","District 14 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1381
@@ -26347,8 +26347,8 @@
 "15","District 15 - Absentee ","State House","15","REP ","LeDoux, Gabrielle ",653
 "15","District 15 - Absentee ","State House","15","DEM ","McCormack, Patrick M ",236
 "15","District 15 - Absentee ","State House","15","NP ","Write-in 30 ",4
-"15","District 15 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",739
-"15","District 15 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",274
+"15","District 15 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",739
+"15","District 15 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",274
 "15","District 15 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",444
 "15","District 15 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",540
 "15","District 15 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",607
@@ -26419,8 +26419,8 @@
 "16","District 16 - Absentee ","State House","16","NA ","Sharrock, Ian ",40
 "16","District 16 - Absentee ","State House","16","DEM ","Spohnholz, Ivy ",412
 "16","District 16 - Absentee ","State House","16","NP ","Write-in 40 ",1
-"16","District 16 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",768
-"16","District 16 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",278
+"16","District 16 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",768
+"16","District 16 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",278
 "16","District 16 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",451
 "16","District 16 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",557
 "16","District 16 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",624
@@ -26486,8 +26486,8 @@
 "17","District 17 - Absentee ","U.S. House","1","NP ","Write-in 50 ",1
 "17","District 17 - Absentee ","State House","17","DEM ","Josephson, Andrew L. ",596
 "17","District 17 - Absentee ","State House","17","NP ","Write-in 20 ",48
-"17","District 17 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",754
-"17","District 17 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",268
+"17","District 17 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",754
+"17","District 17 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",268
 "17","District 17 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",523
 "17","District 17 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",459
 "17","District 17 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",574
@@ -26554,8 +26554,8 @@
 "18","District 18 - Absentee ","State House","18","DEM ","Drummond, Harriet A. ",413
 "18","District 18 - Absentee ","State House","18","REP ","Gordon, Michael W.  ",352
 "18","District 18 - Absentee ","State House","18","NP ","Write-in 30 ",6
-"18","District 18 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",709
-"18","District 18 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",295
+"18","District 18 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",709
+"18","District 18 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",295
 "18","District 18 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",489
 "18","District 18 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",477
 "18","District 18 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",568
@@ -26623,8 +26623,8 @@
 "19","District 19 - Absentee ","State Senate","J","NP ","Write-in 20 ",36
 "19","District 19 - Absentee ","State House","19","DEM ","Tarr, Geran ",286
 "19","District 19 - Absentee ","State House","19","NP ","Write-in 20 ",28
-"19","District 19 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",354
-"19","District 19 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",139
+"19","District 19 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",354
+"19","District 19 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",139
 "19","District 19 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",239
 "19","District 19 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",236
 "19","District 19 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",281
@@ -26692,8 +26692,8 @@
 "20","District 20 - Absentee ","State Senate","J","NP ","Write-in 20 ",65
 "20","District 20 - Absentee ","State House","20","DEM ","Gara, Les S.  ",638
 "20","District 20 - Absentee ","State House","20","NP ","Write-in 20 ",70
-"20","District 20 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",792
-"20","District 20 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",291
+"20","District 20 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",792
+"20","District 20 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",291
 "20","District 20 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",567
 "20","District 20 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",467
 "20","District 20 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",629
@@ -26760,8 +26760,8 @@
 "21","District 21 - Absentee ","State House","21","REP ","Stewart, Marilyn ",451
 "21","District 21 - Absentee ","State House","21","DEM ","Claman, Matt ",488
 "21","District 21 - Absentee ","State House","21","NP ","Write-in 30 ",5
-"21","District 21 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",776
-"21","District 21 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",319
+"21","District 21 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",776
+"21","District 21 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",319
 "21","District 21 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",538
 "21","District 21 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",521
 "21","District 21 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",653
@@ -26829,8 +26829,8 @@
 "22","District 22 - Absentee ","State House","22","REP ","Vazquez, Liz ",456
 "22","District 22 - Absentee ","State House","22","NA ","Grenn, Jason S.  ",351
 "22","District 22 - Absentee ","State House","22","NP ","Write-in 40 ",6
-"22","District 22 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",717
-"22","District 22 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",323
+"22","District 22 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",717
+"22","District 22 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",323
 "22","District 22 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",445
 "22","District 22 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",565
 "22","District 22 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",607
@@ -26901,8 +26901,8 @@
 "23","District 23 - Absentee ","State House","23","DEM ","Tuck, Chris S.  ",321
 "23","District 23 - Absentee ","State House","23","REP ","Huit, Timothy R.  ",328
 "23","District 23 - Absentee ","State House","23","NP ","Write-in 30 ",0
-"23","District 23 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",563
-"23","District 23 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",234
+"23","District 23 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",563
+"23","District 23 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",234
 "23","District 23 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",350
 "23","District 23 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",430
 "23","District 23 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",432
@@ -26973,8 +26973,8 @@
 "24","District 24 - Absentee ","State House","24","DEM ","Levi, Sue ",451
 "24","District 24 - Absentee ","State House","24","REP ","Kopp, Charles M.  ",757
 "24","District 24 - Absentee ","State House","24","NP ","Write-in 30 ",2
-"24","District 24 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",902
-"24","District 24 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",451
+"24","District 24 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",902
+"24","District 24 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",451
 "24","District 24 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",574
 "24","District 24 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",748
 "24","District 24 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",793
@@ -27041,8 +27041,8 @@
 "25","District 25 - Absentee ","State House","25","DEM ","Higgins, Pat ",361
 "25","District 25 - Absentee ","State House","25","REP ","Millett, Charisse E. ",479
 "25","District 25 - Absentee ","State House","25","NP ","Write-in 30 ",4
-"25","District 25 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",712
-"25","District 25 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",285
+"25","District 25 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",712
+"25","District 25 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",285
 "25","District 25 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",435
 "25","District 25 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",525
 "25","District 25 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",565
@@ -27109,8 +27109,8 @@
 "26","District 26 - Absentee ","State House","26","REP ","Birch, Chris ",711
 "26","District 26 - Absentee ","State House","26","DEM ","Gillespie, David M.  ",364
 "26","District 26 - Absentee ","State House","26","NP ","Write-in 30 ",6
-"26","District 26 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",795
-"26","District 26 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",445
+"26","District 26 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",795
+"26","District 26 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",445
 "26","District 26 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",531
 "26","District 26 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",660
 "26","District 26 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",690
@@ -27180,8 +27180,8 @@
 "27","District 27 - Absentee ","State House","27","REP ","Pruitt, Lance ",639
 "27","District 27 - Absentee ","State House","27","DEM ","Crawford, Harry T. J ",476
 "27","District 27 - Absentee ","State House","27","NP ","Write-in 30 ",0
-"27","District 27 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",862
-"27","District 27 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",406
+"27","District 27 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",862
+"27","District 27 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",406
 "27","District 27 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",550
 "27","District 27 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",671
 "27","District 27 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",725
@@ -27251,8 +27251,8 @@
 "28","District 28 - Absentee ","State House","28","REP ","Johnston, Jennifer B ",1019
 "28","District 28 - Absentee ","State House","28","DEM ","Cote, Shirley A.  ",645
 "28","District 28 - Absentee ","State House","28","NP ","Write-in 30 ",7
-"28","District 28 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1160
-"28","District 28 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",684
+"28","District 28 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1160
+"28","District 28 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",684
 "28","District 28 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",837
 "28","District 28 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",946
 "28","District 28 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1003
@@ -27318,8 +27318,8 @@
 "29","District 29 - Absentee ","U.S. House","1","NP ","Write-in 50 ",13
 "29","District 29 - Absentee ","State House","29","REP ","Chenault, Charles M. ",2315
 "29","District 29 - Absentee ","State House","29","NP ","Write-in 20 ",192
-"29","District 29 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",2008
-"29","District 29 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",1187
+"29","District 29 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",2008
+"29","District 29 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",1187
 "29","District 29 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1075
 "29","District 29 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",2005
 "29","District 29 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1345
@@ -27388,8 +27388,8 @@
 "30","District 30 - Absentee ","State House","30","CON ","Myers, J. R.  ",132
 "30","District 30 - Absentee ","State House","30","REP ","Knopp, Gary A.  ",1815
 "30","District 30 - Absentee ","State House","30","NP ","Write-in 50 ",9
-"30","District 30 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1826
-"30","District 30 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",1060
+"30","District 30 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1826
+"30","District 30 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",1060
 "30","District 30 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1015
 "30","District 30 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1783
 "30","District 30 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1223
@@ -27457,8 +27457,8 @@
 "31","District 31 - Absentee ","State Senate","P","NP ","Write-in 20 ",121
 "31","District 31 - Absentee ","State House","31","REP ","Seaton, Paul ",2754
 "31","District 31 - Absentee ","State House","31","NP ","Write-in 20 ",131
-"31","District 31 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",2389
-"31","District 31 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",1100
+"31","District 31 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",2389
+"31","District 31 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",1100
 "31","District 31 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1541
 "31","District 31 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1817
 "31","District 31 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1654
@@ -27528,8 +27528,8 @@
 "32","District 32 - Absentee ","State House","32","REP ","Stutes, Louise ",906
 "32","District 32 - Absentee ","State House","32","DEM ","Watkins, Brent L.  ",424
 "32","District 32 - Absentee ","State House","32","NP ","Write-in 40 ",6
-"32","District 32 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1532
-"32","District 32 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",642
+"32","District 32 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1532
+"32","District 32 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",642
 "32","District 32 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",972
 "32","District 32 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1097
 "32","District 32 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1333
@@ -27603,8 +27603,8 @@
 "33","District 33 - Absentee ","U.S. House","1","NP ","Write-in 50 ",4
 "33","District 33 - Absentee ","State House","33","DEM ","Kito, Sam S. III ",1345
 "33","District 33 - Absentee ","State House","33","NP ","Write-in 20 ",68
-"33","District 33 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1352
-"33","District 33 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",428
+"33","District 33 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1352
+"33","District 33 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",428
 "33","District 33 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1012
 "33","District 33 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",693
 "33","District 33 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1084
@@ -27640,11 +27640,11 @@
 "34","District 34 - Absentee ","U.S. House","1","NA ","Souphanavong, Bernie ",24
 "34","District 34 - Absentee ","U.S. House","1","REP ","Young, Don ",526
 "34","District 34 - Absentee ","U.S. House","1","NP ","Write-in 50 ",4
-"34","District 34 - Absentee ","State House","34","REP ","Muñoz, Cathy ",554
+"34","District 34 - Absentee ","State House","34","REP ","MuÃ±oz, Cathy ",554
 "34","District 34 - Absentee ","State House","34","DEM ","Parish, Justin ",514
 "34","District 34 - Absentee ","State House","34","NP ","Write-in 30 ",2
-"34","District 34 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",862
-"34","District 34 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",312
+"34","District 34 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",862
+"34","District 34 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",312
 "34","District 34 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",578
 "34","District 34 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",547
 "34","District 34 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",719
@@ -27685,8 +27685,8 @@
 "35","District 35 - Absentee ","State House","35","REP ","Finkenbinder, Sheila ",1209
 "35","District 35 - Absentee ","State House","35","DEM ","Kreiss-Tomkins, Jona ",1637
 "35","District 35 - Absentee ","State House","35","NP ","Write-in 30 ",15
-"35","District 35 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",2096
-"35","District 35 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",774
+"35","District 35 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",2096
+"35","District 35 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",774
 "35","District 35 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1441
 "35","District 35 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1314
 "35","District 35 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1571
@@ -27728,8 +27728,8 @@
 "36","District 36 - Absentee ","State House","36","REP ","Sivertsen, Robert W. ",798
 "36","District 36 - Absentee ","State House","36","NA ","Ortiz, Daniel H.  ",999
 "36","District 36 - Absentee ","State House","36","NP ","Write-in 40 ",4
-"36","District 36 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1328
-"36","District 36 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",580
+"36","District 36 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1328
+"36","District 36 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",580
 "36","District 36 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",835
 "36","District 36 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1007
 "36","District 36 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",1135
@@ -27768,8 +27768,8 @@
 "37","District 37 - Absentee ","State House","37","DEM ","Edgmon, Bryce E.  ",586
 "37","District 37 - Absentee ","State House","37","REP ","Weatherby, William W ",424
 "37","District 37 - Absentee ","State House","37","NP ","Write-in 30 ",12
-"37","District 37 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",813
-"37","District 37 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",284
+"37","District 37 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",813
+"37","District 37 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",284
 "37","District 37 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",524
 "37","District 37 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",539
 "37","District 37 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",605
@@ -27851,8 +27851,8 @@
 "38","District 38 - Absentee ","U.S. House","1","NP ","Write-in 50 ",0
 "38","District 38 - Absentee ","State House","38","DEM ","Fansler, Zach ",389
 "38","District 38 - Absentee ","State House","38","NP ","Write-in 20 ",33
-"38","District 38 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",391
-"38","District 38 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",123
+"38","District 38 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",391
+"38","District 38 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",123
 "38","District 38 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",276
 "38","District 38 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",233
 "38","District 38 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",317
@@ -27900,8 +27900,8 @@
 "39","District 39 - Absentee ","State Senate","T","NP ","Write-in 20 ",16
 "39","District 39 - Absentee ","State House","39","DEM ","Foster, Neal W.  ",262
 "39","District 39 - Absentee ","State House","39","NP ","Write-in 20 ",20
-"39","District 39 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",263
-"39","District 39 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",76
+"39","District 39 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",263
+"39","District 39 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",76
 "39","District 39 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",190
 "39","District 39 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",141
 "39","District 39 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",204
@@ -27949,8 +27949,8 @@
 "40","District 40 - Absentee ","State Senate","T","NP ","Write-in 20 ",23
 "40","District 40 - Absentee ","State House","40","DEM ","Westlake, Dean ",281
 "40","District 40 - Absentee ","State House","40","NP ","Write-in 30 ",96
-"40","District 40 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",384
-"40","District 40 - Absentee ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",118
+"40","District 40 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",384
+"40","District 40 - Absentee ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",118
 "40","District 40 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",281
 "40","District 40 - Absentee ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",204
 "40","District 40 - Absentee ","Supreme Crt-Justice Bolger ","","NP ","YES ",289
@@ -28015,8 +28015,8 @@
 "1","District 1 - Question ","U.S. House","1","NP ","Write-in 50 ",2
 "1","District 1 - Question ","State House","1","DEM ","Kawasaki, Scott J.  ",98
 "1","District 1 - Question ","State House","1","NP ","Write-in 20 ",3
-"1","District 1 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",265
-"1","District 1 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",111
+"1","District 1 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",265
+"1","District 1 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",111
 "1","District 1 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",164
 "1","District 1 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",201
 "1","District 1 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",202
@@ -28063,8 +28063,8 @@
 "2","District 2 - Question ","State House","2","REP ","Thompson, Steve M.  ",40
 "2","District 2 - Question ","State House","2","DEM ","Holdaway, Truno N. L ",12
 "2","District 2 - Question ","State House","2","NP ","Write-in 30 ",0
-"2","District 2 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",185
-"2","District 2 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",83
+"2","District 2 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",185
+"2","District 2 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",83
 "2","District 2 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",88
 "2","District 2 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",171
 "2","District 2 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",145
@@ -28115,8 +28115,8 @@
 "3","District 3 - Question ","State House","3","REP ","Wilson, Tammie ",103
 "3","District 3 - Question ","State House","3","NA ","Olson, Jeanne L.  ",70
 "3","District 3 - Question ","State House","3","NP ","Write-in 40 ",1
-"3","District 3 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",248
-"3","District 3 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",127
+"3","District 3 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",248
+"3","District 3 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",127
 "3","District 3 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",125
 "3","District 3 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",234
 "3","District 3 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",167
@@ -28165,8 +28165,8 @@
 "4","District 4 - Question ","State Senate","B","NP ","Write-in 30 ",0
 "4","District 4 - Question ","State House","4","DEM ","Guttenberg, David ",67
 "4","District 4 - Question ","State House","4","NP ","Write-in 20 ",5
-"4","District 4 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",248
-"4","District 4 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",130
+"4","District 4 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",248
+"4","District 4 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",130
 "4","District 4 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",146
 "4","District 4 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",207
 "4","District 4 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",163
@@ -28213,8 +28213,8 @@
 "5","District 5 - Question ","State House","5","REP ","Lojewski, Aaron ",40
 "5","District 5 - Question ","State House","5","DEM ","Wool, Adam ",36
 "5","District 5 - Question ","State House","5","NP ","Write-in 30 ",0
-"5","District 5 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",245
-"5","District 5 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",108
+"5","District 5 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",245
+"5","District 5 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",108
 "5","District 5 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",128
 "5","District 5 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",203
 "5","District 5 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",167
@@ -28261,8 +28261,8 @@
 "6","District 6 - Question ","State House","6","REP ","Talerico, David M.  ",63
 "6","District 6 - Question ","State House","6","DEM ","Land, Jason T.  ",26
 "6","District 6 - Question ","State House","6","NP ","Write-in 40 ",0
-"6","District 6 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",229
-"6","District 6 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",122
+"6","District 6 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",229
+"6","District 6 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",122
 "6","District 6 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "6","District 6 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",210
 "6","District 6 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",160
@@ -28347,8 +28347,8 @@
 "7","District 7 - Question ","State House","7","REP ","Sullivan-Leonard, Co ",108
 "7","District 7 - Question ","State House","7","DEM ","Olson, Sherie A.  ",23
 "7","District 7 - Question ","State House","7","NP ","Write-in 30 ",0
-"7","District 7 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",364
-"7","District 7 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",192
+"7","District 7 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",364
+"7","District 7 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",192
 "7","District 7 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",191
 "7","District 7 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",341
 "7","District 7 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",227
@@ -28417,8 +28417,8 @@
 "8","District 8 - Question ","State House","8","DEM ","Jones, Gregory I.  ",15
 "8","District 8 - Question ","State House","8","REP ","Neuman, Mark A.  ",71
 "8","District 8 - Question ","State House","8","NP ","Write-in 30 ",2
-"8","District 8 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",208
-"8","District 8 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",131
+"8","District 8 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",208
+"8","District 8 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",131
 "8","District 8 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",113
 "8","District 8 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",206
 "8","District 8 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",123
@@ -28485,8 +28485,8 @@
 "9","District 9 - Question ","State House","9","REP ","Rauscher, George ",51
 "9","District 9 - Question ","State House","9","CON ","Goode, Pamela ",49
 "9","District 9 - Question ","State House","9","NP ","Write-in 30 ",2
-"9","District 9 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",242
-"9","District 9 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",131
+"9","District 9 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",242
+"9","District 9 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",131
 "9","District 9 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",121
 "9","District 9 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",234
 "9","District 9 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",157
@@ -28569,8 +28569,8 @@
 "10","District 10 - Question ","State House","10","DEM ","Faye-Brazel, Patrici ",30
 "10","District 10 - Question ","State House","10","REP ","Eastman, David ",122
 "10","District 10 - Question ","State House","10","NP ","Write-in 30 ",2
-"10","District 10 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",287
-"10","District 10 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",224
+"10","District 10 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",287
+"10","District 10 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",224
 "10","District 10 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",157
 "10","District 10 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",328
 "10","District 10 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",195
@@ -28640,8 +28640,8 @@
 "11","District 11 - Question ","State House","11","REP ","Johnson, DeLena ",113
 "11","District 11 - Question ","State House","11","NA ","Verrall, Bert ",61
 "11","District 11 - Question ","State House","11","NP ","Write-in 30 ",1
-"11","District 11 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",403
-"11","District 11 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",240
+"11","District 11 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",403
+"11","District 11 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",240
 "11","District 11 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",234
 "11","District 11 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",373
 "11","District 11 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",259
@@ -28712,8 +28712,8 @@
 "12","District 12 - Question ","State House","12","CON ","Perry, Karen ",10
 "12","District 12 - Question ","State House","12","DEM ","Wehmhoff, Gretchen L ",20
 "12","District 12 - Question ","State House","12","NP ","Write-in 40 ",2
-"12","District 12 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",218
-"12","District 12 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",138
+"12","District 12 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",218
+"12","District 12 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",138
 "12","District 12 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",113
 "12","District 12 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",240
 "12","District 12 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",154
@@ -28779,8 +28779,8 @@
 "13","District 13 - Question ","U.S. House","1","NP ","Write-in 50 ",0
 "13","District 13 - Question ","State House","13","REP ","Saddler, Dan ",66
 "13","District 13 - Question ","State House","13","NP ","Write-in 20 ",2
-"13","District 13 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",235
-"13","District 13 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",109
+"13","District 13 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",235
+"13","District 13 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",109
 "13","District 13 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",118
 "13","District 13 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",207
 "13","District 13 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",162
@@ -28847,8 +28847,8 @@
 "14","District 14 - Question ","State House","14","NA ","Hackenmueller, Joe ",40
 "14","District 14 - Question ","State House","14","REP ","Reinbold, Lora ",68
 "14","District 14 - Question ","State House","14","NP ","Write-in 30 ",1
-"14","District 14 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",220
-"14","District 14 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",97
+"14","District 14 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",220
+"14","District 14 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",97
 "14","District 14 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",104
 "14","District 14 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",201
 "14","District 14 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",128
@@ -28918,8 +28918,8 @@
 "15","District 15 - Question ","State House","15","REP ","LeDoux, Gabrielle ",59
 "15","District 15 - Question ","State House","15","DEM ","McCormack, Patrick M ",22
 "15","District 15 - Question ","State House","15","NP ","Write-in 30 ",1
-"15","District 15 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",276
-"15","District 15 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",95
+"15","District 15 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",276
+"15","District 15 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",95
 "15","District 15 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",171
 "15","District 15 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",187
 "15","District 15 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",188
@@ -28990,8 +28990,8 @@
 "16","District 16 - Question ","State House","16","NA ","Sharrock, Ian ",6
 "16","District 16 - Question ","State House","16","DEM ","Spohnholz, Ivy ",39
 "16","District 16 - Question ","State House","16","NP ","Write-in 40 ",0
-"16","District 16 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",323
-"16","District 16 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",102
+"16","District 16 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",323
+"16","District 16 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",102
 "16","District 16 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",199
 "16","District 16 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",205
 "16","District 16 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",230
@@ -29057,8 +29057,8 @@
 "17","District 17 - Question ","U.S. House","1","NP ","Write-in 50 ",2
 "17","District 17 - Question ","State House","17","DEM ","Josephson, Andrew L. ",49
 "17","District 17 - Question ","State House","17","NP ","Write-in 20 ",3
-"17","District 17 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",354
-"17","District 17 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",159
+"17","District 17 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",354
+"17","District 17 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",159
 "17","District 17 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",233
 "17","District 17 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",250
 "17","District 17 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",246
@@ -29125,8 +29125,8 @@
 "18","District 18 - Question ","State House","18","DEM ","Drummond, Harriet A. ",45
 "18","District 18 - Question ","State House","18","REP ","Gordon, Michael W.  ",43
 "18","District 18 - Question ","State House","18","NP ","Write-in 30 ",1
-"18","District 18 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",445
-"18","District 18 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",152
+"18","District 18 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",445
+"18","District 18 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",152
 "18","District 18 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",277
 "18","District 18 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",290
 "18","District 18 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",293
@@ -29194,8 +29194,8 @@
 "19","District 19 - Question ","State Senate","J","NP ","Write-in 20 ",4
 "19","District 19 - Question ","State House","19","DEM ","Tarr, Geran ",70
 "19","District 19 - Question ","State House","19","NP ","Write-in 20 ",2
-"19","District 19 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",235
-"19","District 19 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",94
+"19","District 19 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",235
+"19","District 19 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",94
 "19","District 19 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",156
 "19","District 19 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",168
 "19","District 19 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",162
@@ -29263,8 +29263,8 @@
 "20","District 20 - Question ","State Senate","J","NP ","Write-in 20 ",6
 "20","District 20 - Question ","State House","20","DEM ","Gara, Les S.  ",50
 "20","District 20 - Question ","State House","20","NP ","Write-in 20 ",6
-"20","District 20 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",295
-"20","District 20 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",128
+"20","District 20 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",295
+"20","District 20 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",128
 "20","District 20 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",175
 "20","District 20 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",219
 "20","District 20 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",205
@@ -29331,8 +29331,8 @@
 "21","District 21 - Question ","State House","21","REP ","Stewart, Marilyn ",39
 "21","District 21 - Question ","State House","21","DEM ","Claman, Matt ",33
 "21","District 21 - Question ","State House","21","NP ","Write-in 30 ",1
-"21","District 21 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",209
-"21","District 21 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",99
+"21","District 21 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",209
+"21","District 21 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",99
 "21","District 21 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",142
 "21","District 21 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",150
 "21","District 21 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",147
@@ -29400,8 +29400,8 @@
 "22","District 22 - Question ","State House","22","REP ","Vazquez, Liz ",38
 "22","District 22 - Question ","State House","22","NA ","Grenn, Jason S.  ",27
 "22","District 22 - Question ","State House","22","NP ","Write-in 40 ",2
-"22","District 22 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",233
-"22","District 22 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",102
+"22","District 22 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",233
+"22","District 22 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",102
 "22","District 22 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",129
 "22","District 22 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",191
 "22","District 22 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",160
@@ -29472,8 +29472,8 @@
 "23","District 23 - Question ","State House","23","DEM ","Tuck, Chris S.  ",39
 "23","District 23 - Question ","State House","23","REP ","Huit, Timothy R.  ",33
 "23","District 23 - Question ","State House","23","NP ","Write-in 30 ",0
-"23","District 23 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",266
-"23","District 23 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",132
+"23","District 23 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",266
+"23","District 23 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",132
 "23","District 23 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",182
 "23","District 23 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",196
 "23","District 23 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",181
@@ -29544,8 +29544,8 @@
 "24","District 24 - Question ","State House","24","DEM ","Levi, Sue ",31
 "24","District 24 - Question ","State House","24","REP ","Kopp, Charles M.  ",56
 "24","District 24 - Question ","State House","24","NP ","Write-in 30 ",0
-"24","District 24 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",206
-"24","District 24 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",99
+"24","District 24 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",206
+"24","District 24 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",99
 "24","District 24 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",111
 "24","District 24 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",177
 "24","District 24 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",134
@@ -29612,8 +29612,8 @@
 "25","District 25 - Question ","State House","25","DEM ","Higgins, Pat ",49
 "25","District 25 - Question ","State House","25","REP ","Millett, Charisse E. ",53
 "25","District 25 - Question ","State House","25","NP ","Write-in 30 ",0
-"25","District 25 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",276
-"25","District 25 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",133
+"25","District 25 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",276
+"25","District 25 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",133
 "25","District 25 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",168
 "25","District 25 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",229
 "25","District 25 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",192
@@ -29680,8 +29680,8 @@
 "26","District 26 - Question ","State House","26","REP ","Birch, Chris ",79
 "26","District 26 - Question ","State House","26","DEM ","Gillespie, David M.  ",38
 "26","District 26 - Question ","State House","26","NP ","Write-in 30 ",1
-"26","District 26 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",292
-"26","District 26 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",147
+"26","District 26 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",292
+"26","District 26 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",147
 "26","District 26 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",186
 "26","District 26 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",223
 "26","District 26 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",203
@@ -29751,8 +29751,8 @@
 "27","District 27 - Question ","State House","27","REP ","Pruitt, Lance ",44
 "27","District 27 - Question ","State House","27","DEM ","Crawford, Harry T. J ",30
 "27","District 27 - Question ","State House","27","NP ","Write-in 30 ",0
-"27","District 27 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",249
-"27","District 27 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",111
+"27","District 27 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",249
+"27","District 27 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",111
 "27","District 27 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",148
 "27","District 27 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",193
 "27","District 27 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",167
@@ -29822,8 +29822,8 @@
 "28","District 28 - Question ","State House","28","REP ","Johnston, Jennifer B ",35
 "28","District 28 - Question ","State House","28","DEM ","Cote, Shirley A.  ",28
 "28","District 28 - Question ","State House","28","NP ","Write-in 30 ",2
-"28","District 28 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",198
-"28","District 28 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",95
+"28","District 28 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",198
+"28","District 28 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",95
 "28","District 28 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",113
 "28","District 28 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",159
 "28","District 28 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",128
@@ -29889,8 +29889,8 @@
 "29","District 29 - Question ","U.S. House","1","NP ","Write-in 50 ",1
 "29","District 29 - Question ","State House","29","REP ","Chenault, Charles M. ",90
 "29","District 29 - Question ","State House","29","NP ","Write-in 20 ",6
-"29","District 29 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",193
-"29","District 29 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",97
+"29","District 29 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",193
+"29","District 29 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",97
 "29","District 29 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",91
 "29","District 29 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",180
 "29","District 29 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",93
@@ -29959,8 +29959,8 @@
 "30","District 30 - Question ","State House","30","CON ","Myers, J. R.  ",21
 "30","District 30 - Question ","State House","30","REP ","Knopp, Gary A.  ",134
 "30","District 30 - Question ","State House","30","NP ","Write-in 50 ",2
-"30","District 30 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",308
-"30","District 30 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",185
+"30","District 30 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",308
+"30","District 30 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",185
 "30","District 30 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",154
 "30","District 30 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",310
 "30","District 30 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",195
@@ -30028,8 +30028,8 @@
 "31","District 31 - Question ","State Senate","P","NP ","Write-in 20 ",3
 "31","District 31 - Question ","State House","31","REP ","Seaton, Paul ",141
 "31","District 31 - Question ","State House","31","NP ","Write-in 20 ",2
-"31","District 31 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",211
-"31","District 31 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",104
+"31","District 31 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",211
+"31","District 31 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",104
 "31","District 31 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",124
 "31","District 31 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",178
 "31","District 31 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",108
@@ -30099,8 +30099,8 @@
 "32","District 32 - Question ","State House","32","REP ","Stutes, Louise ",77
 "32","District 32 - Question ","State House","32","DEM ","Watkins, Brent L.  ",21
 "32","District 32 - Question ","State House","32","NP ","Write-in 40 ",1
-"32","District 32 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",196
-"32","District 32 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",77
+"32","District 32 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",196
+"32","District 32 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",77
 "32","District 32 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",101
 "32","District 32 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",147
 "32","District 32 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",137
@@ -30174,8 +30174,8 @@
 "33","District 33 - Question ","U.S. House","1","NP ","Write-in 50 ",4
 "33","District 33 - Question ","State House","33","DEM ","Kito, Sam S. III ",200
 "33","District 33 - Question ","State House","33","NP ","Write-in 20 ",9
-"33","District 33 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",343
-"33","District 33 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",129
+"33","District 33 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",343
+"33","District 33 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",129
 "33","District 33 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",232
 "33","District 33 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",209
 "33","District 33 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",271
@@ -30211,11 +30211,11 @@
 "34","District 34 - Question ","U.S. House","1","NA ","Souphanavong, Bernie ",18
 "34","District 34 - Question ","U.S. House","1","REP ","Young, Don ",197
 "34","District 34 - Question ","U.S. House","1","NP ","Write-in 50 ",0
-"34","District 34 - Question ","State House","34","REP ","Muñoz, Cathy ",119
+"34","District 34 - Question ","State House","34","REP ","MuÃ±oz, Cathy ",119
 "34","District 34 - Question ","State House","34","DEM ","Parish, Justin ",134
 "34","District 34 - Question ","State House","34","NP ","Write-in 30 ",0
-"34","District 34 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",294
-"34","District 34 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",113
+"34","District 34 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",294
+"34","District 34 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",113
 "34","District 34 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",192
 "34","District 34 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",196
 "34","District 34 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",218
@@ -30256,8 +30256,8 @@
 "35","District 35 - Question ","State House","35","REP ","Finkenbinder, Sheila ",60
 "35","District 35 - Question ","State House","35","DEM ","Kreiss-Tomkins, Jona ",61
 "35","District 35 - Question ","State House","35","NP ","Write-in 30 ",1
-"35","District 35 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",136
-"35","District 35 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",62
+"35","District 35 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",136
+"35","District 35 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",62
 "35","District 35 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",85
 "35","District 35 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",106
 "35","District 35 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",94
@@ -30299,8 +30299,8 @@
 "36","District 36 - Question ","State House","36","REP ","Sivertsen, Robert W. ",199
 "36","District 36 - Question ","State House","36","NA ","Ortiz, Daniel H.  ",199
 "36","District 36 - Question ","State House","36","NP ","Write-in 40 ",1
-"36","District 36 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",330
-"36","District 36 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",161
+"36","District 36 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",330
+"36","District 36 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",161
 "36","District 36 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",207
 "36","District 36 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",269
 "36","District 36 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",266
@@ -30339,8 +30339,8 @@
 "37","District 37 - Question ","State House","37","DEM ","Edgmon, Bryce E.  ",43
 "37","District 37 - Question ","State House","37","REP ","Weatherby, William W ",28
 "37","District 37 - Question ","State House","37","NP ","Write-in 30 ",3
-"37","District 37 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",141
-"37","District 37 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",58
+"37","District 37 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",141
+"37","District 37 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",58
 "37","District 37 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",82
 "37","District 37 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",110
 "37","District 37 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",91
@@ -30422,8 +30422,8 @@
 "38","District 38 - Question ","U.S. House","1","NP ","Write-in 50 ",5
 "38","District 38 - Question ","State House","38","DEM ","Fansler, Zach ",175
 "38","District 38 - Question ","State House","38","NP ","Write-in 20 ",5
-"38","District 38 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",216
-"38","District 38 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",105
+"38","District 38 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",216
+"38","District 38 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",105
 "38","District 38 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",161
 "38","District 38 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",154
 "38","District 38 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",179
@@ -30471,8 +30471,8 @@
 "39","District 39 - Question ","State Senate","T","NP ","Write-in 20 ",1
 "39","District 39 - Question ","State House","39","DEM ","Foster, Neal W.  ",86
 "39","District 39 - Question ","State House","39","NP ","Write-in 20 ",2
-"39","District 39 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",147
-"39","District 39 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",61
+"39","District 39 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",147
+"39","District 39 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",61
 "39","District 39 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",113
 "39","District 39 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",90
 "39","District 39 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",124
@@ -30520,8 +30520,8 @@
 "40","District 40 - Question ","State Senate","T","NP ","Write-in 20 ",3
 "40","District 40 - Question ","State House","40","DEM ","Westlake, Dean ",78
 "40","District 40 - Question ","State House","40","NP ","Write-in 30 ",18
-"40","District 40 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",154
-"40","District 40 - Question ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",85
+"40","District 40 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",154
+"40","District 40 - Question ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",85
 "40","District 40 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",108
 "40","District 40 - Question ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",125
 "40","District 40 - Question ","Supreme Crt-Justice Bolger ","","NP ","YES ",113
@@ -30567,8 +30567,8 @@
 "1","District 1 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",4
 "1","District 1 - Early Voting ","State House","1","DEM ","Kawasaki, Scott J.  ",896
 "1","District 1 - Early Voting ","State House","1","NP ","Write-in 20 ",67
-"1","District 1 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",824
-"1","District 1 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",328
+"1","District 1 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",824
+"1","District 1 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",328
 "1","District 1 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",556
 "1","District 1 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",563
 "1","District 1 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",636
@@ -30615,8 +30615,8 @@
 "2","District 2 - Early Voting ","State House","2","REP ","Thompson, Steve M.  ",455
 "2","District 2 - Early Voting ","State House","2","DEM ","Holdaway, Truno N. L ",257
 "2","District 2 - Early Voting ","State House","2","NP ","Write-in 30 ",5
-"2","District 2 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",518
-"2","District 2 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",212
+"2","District 2 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",518
+"2","District 2 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",212
 "2","District 2 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",319
 "2","District 2 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",393
 "2","District 2 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",404
@@ -30667,8 +30667,8 @@
 "3","District 3 - Early Voting ","State House","3","REP ","Wilson, Tammie ",603
 "3","District 3 - Early Voting ","State House","3","NA ","Olson, Jeanne L.  ",349
 "3","District 3 - Early Voting ","State House","3","NP ","Write-in 40 ",2
-"3","District 3 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",696
-"3","District 3 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",358
+"3","District 3 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",696
+"3","District 3 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",358
 "3","District 3 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",341
 "3","District 3 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",692
 "3","District 3 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",514
@@ -30717,8 +30717,8 @@
 "4","District 4 - Early Voting ","State Senate","B","NP ","Write-in 30 ",14
 "4","District 4 - Early Voting ","State House","4","DEM ","Guttenberg, David ",1286
 "4","District 4 - Early Voting ","State House","4","NP ","Write-in 20 ",91
-"4","District 4 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1307
-"4","District 4 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",460
+"4","District 4 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1307
+"4","District 4 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",460
 "4","District 4 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1002
 "4","District 4 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",711
 "4","District 4 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",1072
@@ -30765,8 +30765,8 @@
 "5","District 5 - Early Voting ","State House","5","REP ","Lojewski, Aaron ",553
 "5","District 5 - Early Voting ","State House","5","DEM ","Wool, Adam ",795
 "5","District 5 - Early Voting ","State House","5","NP ","Write-in 30 ",3
-"5","District 5 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",993
-"5","District 5 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",360
+"5","District 5 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",993
+"5","District 5 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",360
 "5","District 5 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",717
 "5","District 5 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",596
 "5","District 5 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",777
@@ -30813,8 +30813,8 @@
 "6","District 6 - Early Voting ","State House","6","REP ","Talerico, David M.  ",396
 "6","District 6 - Early Voting ","State House","6","DEM ","Land, Jason T.  ",221
 "6","District 6 - Early Voting ","State House","6","NP ","Write-in 40 ",1
-"6","District 6 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",400
-"6","District 6 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",229
+"6","District 6 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",400
+"6","District 6 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",229
 "6","District 6 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",253
 "6","District 6 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",362
 "6","District 6 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",303
@@ -30899,8 +30899,8 @@
 "7","District 7 - Early Voting ","State House","7","REP ","Sullivan-Leonard, Co ",1465
 "7","District 7 - Early Voting ","State House","7","DEM ","Olson, Sherie A.  ",489
 "7","District 7 - Early Voting ","State House","7","NP ","Write-in 30 ",13
-"7","District 7 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1268
-"7","District 7 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",820
+"7","District 7 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1268
+"7","District 7 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",820
 "7","District 7 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",715
 "7","District 7 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1281
 "7","District 7 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",893
@@ -30969,8 +30969,8 @@
 "8","District 8 - Early Voting ","State House","8","DEM ","Jones, Gregory I.  ",294
 "8","District 8 - Early Voting ","State House","8","REP ","Neuman, Mark A.  ",1072
 "8","District 8 - Early Voting ","State House","8","NP ","Write-in 30 ",4
-"8","District 8 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",823
-"8","District 8 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",582
+"8","District 8 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",823
+"8","District 8 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",582
 "8","District 8 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",444
 "8","District 8 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",929
 "8","District 8 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",584
@@ -31037,8 +31037,8 @@
 "9","District 9 - Early Voting ","State House","9","REP ","Rauscher, George ",336
 "9","District 9 - Early Voting ","State House","9","CON ","Goode, Pamela ",168
 "9","District 9 - Early Voting ","State House","9","NP ","Write-in 30 ",18
-"9","District 9 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",361
-"9","District 9 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",206
+"9","District 9 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",361
+"9","District 9 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",206
 "9","District 9 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",209
 "9","District 9 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",330
 "9","District 9 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",272
@@ -31121,8 +31121,8 @@
 "10","District 10 - Early Voting ","State House","10","DEM ","Faye-Brazel, Patrici ",326
 "10","District 10 - Early Voting ","State House","10","REP ","Eastman, David ",969
 "10","District 10 - Early Voting ","State House","10","NP ","Write-in 30 ",4
-"10","District 10 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",752
-"10","District 10 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",573
+"10","District 10 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",752
+"10","District 10 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",573
 "10","District 10 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",453
 "10","District 10 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",820
 "10","District 10 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",575
@@ -31192,8 +31192,8 @@
 "11","District 11 - Early Voting ","State House","11","REP ","Johnson, DeLena ",655
 "11","District 11 - Early Voting ","State House","11","NA ","Verrall, Bert ",289
 "11","District 11 - Early Voting ","State House","11","NP ","Write-in 30 ",3
-"11","District 11 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",576
-"11","District 11 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",406
+"11","District 11 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",576
+"11","District 11 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",406
 "11","District 11 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",336
 "11","District 11 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",617
 "11","District 11 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",426
@@ -31264,8 +31264,8 @@
 "12","District 12 - Early Voting ","State House","12","CON ","Perry, Karen ",82
 "12","District 12 - Early Voting ","State House","12","DEM ","Wehmhoff, Gretchen L ",253
 "12","District 12 - Early Voting ","State House","12","NP ","Write-in 40 ",3
-"12","District 12 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",613
-"12","District 12 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",425
+"12","District 12 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",613
+"12","District 12 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",425
 "12","District 12 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",346
 "12","District 12 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",671
 "12","District 12 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",427
@@ -31331,8 +31331,8 @@
 "13","District 13 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",3
 "13","District 13 - Early Voting ","State House","13","REP ","Saddler, Dan ",324
 "13","District 13 - Early Voting ","State House","13","NP ","Write-in 20 ",40
-"13","District 13 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",289
-"13","District 13 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",151
+"13","District 13 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",289
+"13","District 13 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",151
 "13","District 13 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",183
 "13","District 13 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",240
 "13","District 13 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",198
@@ -31399,8 +31399,8 @@
 "14","District 14 - Early Voting ","State House","14","NA ","Hackenmueller, Joe ",569
 "14","District 14 - Early Voting ","State House","14","REP ","Reinbold, Lora ",543
 "14","District 14 - Early Voting ","State House","14","NP ","Write-in 30 ",3
-"14","District 14 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",762
-"14","District 14 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",367
+"14","District 14 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",762
+"14","District 14 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",367
 "14","District 14 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",523
 "14","District 14 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",565
 "14","District 14 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",639
@@ -31470,8 +31470,8 @@
 "15","District 15 - Early Voting ","State House","15","REP ","LeDoux, Gabrielle ",274
 "15","District 15 - Early Voting ","State House","15","DEM ","McCormack, Patrick M ",229
 "15","District 15 - Early Voting ","State House","15","NP ","Write-in 30 ",2
-"15","District 15 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",357
-"15","District 15 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",160
+"15","District 15 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",357
+"15","District 15 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",160
 "15","District 15 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",245
 "15","District 15 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",254
 "15","District 15 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",268
@@ -31542,8 +31542,8 @@
 "16","District 16 - Early Voting ","State House","16","NA ","Sharrock, Ian ",46
 "16","District 16 - Early Voting ","State House","16","DEM ","Spohnholz, Ivy ",658
 "16","District 16 - Early Voting ","State House","16","NP ","Write-in 40 ",7
-"16","District 16 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",759
-"16","District 16 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",284
+"16","District 16 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",759
+"16","District 16 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",284
 "16","District 16 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",529
 "16","District 16 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",471
 "16","District 16 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",596
@@ -31609,8 +31609,8 @@
 "17","District 17 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",5
 "17","District 17 - Early Voting ","State House","17","DEM ","Josephson, Andrew L. ",728
 "17","District 17 - Early Voting ","State House","17","NP ","Write-in 20 ",56
-"17","District 17 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",678
-"17","District 17 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",271
+"17","District 17 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",678
+"17","District 17 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",271
 "17","District 17 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",478
 "17","District 17 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",438
 "17","District 17 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",555
@@ -31677,8 +31677,8 @@
 "18","District 18 - Early Voting ","State House","18","DEM ","Drummond, Harriet A. ",886
 "18","District 18 - Early Voting ","State House","18","REP ","Gordon, Michael W.  ",523
 "18","District 18 - Early Voting ","State House","18","NP ","Write-in 30 ",7
-"18","District 18 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1018
-"18","District 18 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",405
+"18","District 18 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1018
+"18","District 18 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",405
 "18","District 18 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",752
 "18","District 18 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",623
 "18","District 18 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",865
@@ -31746,8 +31746,8 @@
 "19","District 19 - Early Voting ","State Senate","J","NP ","Write-in 20 ",33
 "19","District 19 - Early Voting ","State House","19","DEM ","Tarr, Geran ",478
 "19","District 19 - Early Voting ","State House","19","NP ","Write-in 20 ",29
-"19","District 19 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",455
-"19","District 19 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",146
+"19","District 19 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",455
+"19","District 19 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",146
 "19","District 19 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",333
 "19","District 19 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",249
 "19","District 19 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",356
@@ -31815,8 +31815,8 @@
 "20","District 20 - Early Voting ","State Senate","J","NP ","Write-in 20 ",70
 "20","District 20 - Early Voting ","State House","20","DEM ","Gara, Les S.  ",1223
 "20","District 20 - Early Voting ","State House","20","NP ","Write-in 20 ",64
-"20","District 20 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1190
-"20","District 20 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",307
+"20","District 20 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1190
+"20","District 20 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",307
 "20","District 20 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",893
 "20","District 20 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",558
 "20","District 20 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",940
@@ -31883,8 +31883,8 @@
 "21","District 21 - Early Voting ","State House","21","REP ","Stewart, Marilyn ",582
 "21","District 21 - Early Voting ","State House","21","DEM ","Claman, Matt ",929
 "21","District 21 - Early Voting ","State House","21","NP ","Write-in 30 ",3
-"21","District 21 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1102
-"21","District 21 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",427
+"21","District 21 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1102
+"21","District 21 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",427
 "21","District 21 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",837
 "21","District 21 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",647
 "21","District 21 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",976
@@ -31952,8 +31952,8 @@
 "22","District 22 - Early Voting ","State House","22","REP ","Vazquez, Liz ",411
 "22","District 22 - Early Voting ","State House","22","NA ","Grenn, Jason S.  ",638
 "22","District 22 - Early Voting ","State House","22","NP ","Write-in 40 ",1
-"22","District 22 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",801
-"22","District 22 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",372
+"22","District 22 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",801
+"22","District 22 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",372
 "22","District 22 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",566
 "22","District 22 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",563
 "22","District 22 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",658
@@ -32024,8 +32024,8 @@
 "23","District 23 - Early Voting ","State House","23","DEM ","Tuck, Chris S.  ",572
 "23","District 23 - Early Voting ","State House","23","REP ","Huit, Timothy R.  ",331
 "23","District 23 - Early Voting ","State House","23","NP ","Write-in 30 ",6
-"23","District 23 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",638
-"23","District 23 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",278
+"23","District 23 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",638
+"23","District 23 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",278
 "23","District 23 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",447
 "23","District 23 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",441
 "23","District 23 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",475
@@ -32096,8 +32096,8 @@
 "24","District 24 - Early Voting ","State House","24","DEM ","Levi, Sue ",747
 "24","District 24 - Early Voting ","State House","24","REP ","Kopp, Charles M.  ",710
 "24","District 24 - Early Voting ","State House","24","NP ","Write-in 30 ",11
-"24","District 24 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1017
-"24","District 24 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",475
+"24","District 24 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1017
+"24","District 24 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",475
 "24","District 24 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",743
 "24","District 24 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",709
 "24","District 24 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",862
@@ -32164,8 +32164,8 @@
 "25","District 25 - Early Voting ","State House","25","DEM ","Higgins, Pat ",611
 "25","District 25 - Early Voting ","State House","25","REP ","Millett, Charisse E. ",460
 "25","District 25 - Early Voting ","State House","25","NP ","Write-in 30 ",6
-"25","District 25 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",769
-"25","District 25 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",312
+"25","District 25 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",769
+"25","District 25 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",312
 "25","District 25 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",543
 "25","District 25 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",498
 "25","District 25 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",616
@@ -32232,8 +32232,8 @@
 "26","District 26 - Early Voting ","State House","26","REP ","Birch, Chris ",737
 "26","District 26 - Early Voting ","State House","26","DEM ","Gillespie, David M.  ",633
 "26","District 26 - Early Voting ","State House","26","NP ","Write-in 30 ",5
-"26","District 26 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",933
-"26","District 26 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",463
+"26","District 26 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",933
+"26","District 26 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",463
 "26","District 26 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",653
 "26","District 26 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",690
 "26","District 26 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",796
@@ -32303,8 +32303,8 @@
 "27","District 27 - Early Voting ","State House","27","REP ","Pruitt, Lance ",483
 "27","District 27 - Early Voting ","State House","27","DEM ","Crawford, Harry T. J ",670
 "27","District 27 - Early Voting ","State House","27","NP ","Write-in 30 ",2
-"27","District 27 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",828
-"27","District 27 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",340
+"27","District 27 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",828
+"27","District 27 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",340
 "27","District 27 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",561
 "27","District 27 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",574
 "27","District 27 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",650
@@ -32374,8 +32374,8 @@
 "28","District 28 - Early Voting ","State House","28","REP ","Johnston, Jennifer B ",928
 "28","District 28 - Early Voting ","State House","28","DEM ","Cote, Shirley A.  ",1014
 "28","District 28 - Early Voting ","State House","28","NP ","Write-in 30 ",4
-"28","District 28 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1352
-"28","District 28 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",642
+"28","District 28 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1352
+"28","District 28 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",642
 "28","District 28 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1001
 "28","District 28 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",936
 "28","District 28 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",1184
@@ -32441,8 +32441,8 @@
 "29","District 29 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",0
 "29","District 29 - Early Voting ","State House","29","REP ","Chenault, Charles M. ",61
 "29","District 29 - Early Voting ","State House","29","NP ","Write-in 20 ",10
-"29","District 29 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",58
-"29","District 29 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",33
+"29","District 29 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",58
+"29","District 29 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",33
 "29","District 29 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",40
 "29","District 29 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",43
 "29","District 29 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",38
@@ -32511,8 +32511,8 @@
 "30","District 30 - Early Voting ","State House","30","CON ","Myers, J. R.  ",5
 "30","District 30 - Early Voting ","State House","30","REP ","Knopp, Gary A.  ",27
 "30","District 30 - Early Voting ","State House","30","NP ","Write-in 50 ",0
-"30","District 30 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",27
-"30","District 30 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",20
+"30","District 30 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",27
+"30","District 30 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",20
 "30","District 30 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",14
 "30","District 30 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",30
 "30","District 30 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",13
@@ -32580,8 +32580,8 @@
 "31","District 31 - Early Voting ","State Senate","P","NP ","Write-in 20 ",4
 "31","District 31 - Early Voting ","State House","31","REP ","Seaton, Paul ",52
 "31","District 31 - Early Voting ","State House","31","NP ","Write-in 20 ",5
-"31","District 31 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",42
-"31","District 31 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",26
+"31","District 31 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",42
+"31","District 31 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",26
 "31","District 31 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",24
 "31","District 31 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",39
 "31","District 31 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",24
@@ -32651,8 +32651,8 @@
 "32","District 32 - Early Voting ","State House","32","REP ","Stutes, Louise ",17
 "32","District 32 - Early Voting ","State House","32","DEM ","Watkins, Brent L.  ",14
 "32","District 32 - Early Voting ","State House","32","NP ","Write-in 40 ",0
-"32","District 32 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",31
-"32","District 32 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",16
+"32","District 32 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",31
+"32","District 32 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",16
 "32","District 32 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",20
 "32","District 32 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "32","District 32 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",23
@@ -32726,8 +32726,8 @@
 "33","District 33 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",2
 "33","District 33 - Early Voting ","State House","33","DEM ","Kito, Sam S. III ",1774
 "33","District 33 - Early Voting ","State House","33","NP ","Write-in 20 ",77
-"33","District 33 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",1648
-"33","District 33 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",466
+"33","District 33 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",1648
+"33","District 33 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",466
 "33","District 33 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1296
 "33","District 33 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",730
 "33","District 33 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",1377
@@ -32763,11 +32763,11 @@
 "34","District 34 - Early Voting ","U.S. House","1","NA ","Souphanavong, Bernie ",57
 "34","District 34 - Early Voting ","U.S. House","1","REP ","Young, Don ",1074
 "34","District 34 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",7
-"34","District 34 - Early Voting ","State House","34","REP ","Muñoz, Cathy ",1257
+"34","District 34 - Early Voting ","State House","34","REP ","MuÃ±oz, Cathy ",1257
 "34","District 34 - Early Voting ","State House","34","DEM ","Parish, Justin ",1571
 "34","District 34 - Early Voting ","State House","34","NP ","Write-in 30 ",15
-"34","District 34 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",2031
-"34","District 34 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",799
+"34","District 34 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",2031
+"34","District 34 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",799
 "34","District 34 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",1566
 "34","District 34 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",1178
 "34","District 34 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",1765
@@ -32808,8 +32808,8 @@
 "35","District 35 - Early Voting ","State House","35","REP ","Finkenbinder, Sheila ",28
 "35","District 35 - Early Voting ","State House","35","DEM ","Kreiss-Tomkins, Jona ",65
 "35","District 35 - Early Voting ","State House","35","NP ","Write-in 30 ",1
-"35","District 35 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",68
-"35","District 35 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",27
+"35","District 35 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",68
+"35","District 35 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",27
 "35","District 35 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",49
 "35","District 35 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",41
 "35","District 35 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",52
@@ -32851,8 +32851,8 @@
 "36","District 36 - Early Voting ","State House","36","REP ","Sivertsen, Robert W. ",4
 "36","District 36 - Early Voting ","State House","36","NA ","Ortiz, Daniel H.  ",16
 "36","District 36 - Early Voting ","State House","36","NP ","Write-in 40 ",0
-"36","District 36 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",11
-"36","District 36 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",10
+"36","District 36 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",11
+"36","District 36 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",10
 "36","District 36 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",6
 "36","District 36 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",15
 "36","District 36 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",14
@@ -32891,8 +32891,8 @@
 "37","District 37 - Early Voting ","State House","37","DEM ","Edgmon, Bryce E.  ",59
 "37","District 37 - Early Voting ","State House","37","REP ","Weatherby, William W ",38
 "37","District 37 - Early Voting ","State House","37","NP ","Write-in 30 ",2
-"37","District 37 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",70
-"37","District 37 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",29
+"37","District 37 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",70
+"37","District 37 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",29
 "37","District 37 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",50
 "37","District 37 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",41
 "37","District 37 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",44
@@ -32974,8 +32974,8 @@
 "38","District 38 - Early Voting ","U.S. House","1","NP ","Write-in 50 ",0
 "38","District 38 - Early Voting ","State House","38","DEM ","Fansler, Zach ",37
 "38","District 38 - Early Voting ","State House","38","NP ","Write-in 20 ",3
-"38","District 38 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",30
-"38","District 38 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",11
+"38","District 38 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",30
+"38","District 38 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",11
 "38","District 38 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",24
 "38","District 38 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",18
 "38","District 38 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",25
@@ -33023,8 +33023,8 @@
 "39","District 39 - Early Voting ","State Senate","T","NP ","Write-in 20 ",28
 "39","District 39 - Early Voting ","State House","39","DEM ","Foster, Neal W.  ",272
 "39","District 39 - Early Voting ","State House","39","NP ","Write-in 20 ",18
-"39","District 39 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",254
-"39","District 39 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",77
+"39","District 39 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",254
+"39","District 39 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",77
 "39","District 39 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",161
 "39","District 39 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",150
 "39","District 39 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",199
@@ -33072,8 +33072,8 @@
 "40","District 40 - Early Voting ","State Senate","T","NP ","Write-in 20 ",2
 "40","District 40 - Early Voting ","State House","40","DEM ","Westlake, Dean ",38
 "40","District 40 - Early Voting ","State House","40","NP ","Write-in 30 ",13
-"40","District 40 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","YES ",35
-"40","District 40 - Early Voting ","Ballot Measure No. 1 – 15PFVR ","","NP ","NO ",24
+"40","District 40 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","YES ",35
+"40","District 40 - Early Voting ","Ballot Measure No. 1 - 15PFVR ","","NP ","NO ",24
 "40","District 40 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","YES ",31
 "40","District 40 - Early Voting ","Ballot Measure No. 2 - SJR2 ","","NP ","NO ",26
 "40","District 40 - Early Voting ","Supreme Crt-Justice Bolger ","","NP ","YES ",33


### PR DESCRIPTION
The original file was encoded in [CP-1252](https://en.wikipedia.org/wiki/Windows-1252). I noticed something was weird when GitHub rendered ` �`. I re-encoded it to utf-8.

Upon re-encoding, the many `�` were now `–` which is Unicode codepoint `\u2013` [which is an en dash](http://www.fileformat.info/info/unicode/char/2013/index.htm).

Using an en dash seemed undesirable, especially since many of the similarly-formatted lines use hyphens. For simplicity and continuity, I converted all of those to hyphens.