### PR TITLE
Bump version of data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-data-tests
-        ref: v0.1.0
+        ref: v0.1.1
         path: data_tests
 
     - name: Run data tests


### PR DESCRIPTION
This updates the data tests to version [0.1.1](https://github.com/openelections/openelections-data-tests/releases/tag/v0.1.1), which fixes a bug with the reported row numbers.
